### PR TITLE
Add scoping for objects bound to sections

### DIFF
--- a/lib/mustache.ml
+++ b/lib/mustache.ml
@@ -150,6 +150,7 @@ module Lookup = struct
       | `Null | `Float _ | `Bool false | `String "" -> `Bool false
       | `Bool true -> `Bool true
       | `A e -> `List e
+      | `O o -> `Scope (`O o)
       | _ -> raise @@ Invalid_param ("section: invalid key: " ^ key)
 end
 
@@ -167,6 +168,7 @@ let rec render m js =
       elems
       |> List.map ~f:(render contents)
       |> String.concat ~sep:""
+    | `Scope obj -> render contents obj
     end
   | Partial s -> to_string m
   | Concat templates ->

--- a/lib_test/test_mustache.ml
+++ b/lib_test/test_mustache.ml
@@ -68,6 +68,11 @@ let mustache_section_list2 _ =
   let vs = [("one","1");("two","2")] in
   assert_equal "one-1two-2" (Mustache.render tmpl @@ js' vs)
 
+let test_scoped _ =
+  let tmpl = Mustache.of_string "{{#item}}{{content}}{{/item}}" in
+  let js = `O [ "item", `O [ "content", `String "internal"] ] in
+  assert_equal "internal" (Mustache.render tmpl js)
+
 let test_html_escape1 _ =
   let html = "<b>foo bar</b>" in
   let escaped = Mustache.escape_html html in
@@ -87,6 +92,7 @@ let suite =
     "bool sections" >:: mustache2;
     "mustache section list 1" >:: mustache_section_list1;
     "mustache section list 2" >:: mustache_section_list2;
+    "object scoped section" >:: test_scoped;
     "test html escaping" >:: test_html_escape1;
     "test sexp conversion" >:: test_sexp_conversion;
   ]


### PR DESCRIPTION
I think this is all that's needed to get scoping for sections bound to objects working.
