### PR TITLE
More features, some bug fixs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: c
+sudo: required
 install: wget https://raw.githubusercontent.com/samoht/ocaml-travisci-skeleton/master/.travis-opam.sh
 script: bash -ex .travis-opam.sh
 env:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ mustache.js logic-less templates in OCaml
 
 Todo/Wish List
 -----------
-* Don't depend on re.str (not threadsafe)
 * Inverted sections
 * Support for ropes
 

--- a/_oasis
+++ b/_oasis
@@ -12,8 +12,7 @@ Library mustache
   BuildTools: ocamlbuild
   Modules:    Mustache
   InternalModules: Mustache_types, Mustache_lexer, Mustache_parser
-  BuildDepends: re.str,
-                ezjsonm,
+  BuildDepends: ezjsonm,
                 sexplib,
                 sexplib.syntax
 
@@ -39,4 +38,3 @@ Executable mustache_cli
   CompiledObject:     best
   Install:            false
   BuildDepends:       mustache
-

--- a/lib/mustache.ml
+++ b/lib/mustache.ml
@@ -1,8 +1,5 @@
-open Sexplib.Std
-open Printf
 open MoreLabels
 include Mustache_types
-open Mustache_parser
 
 module List = ListLabels
 module String = StringLabels

--- a/lib/mustache.ml
+++ b/lib/mustache.ml
@@ -48,6 +48,9 @@ let rec to_formatter fmt = function
   | Partial s ->
      Format.fprintf fmt "{{> %s }}" s
 
+  | Comment s ->
+     Format.fprintf fmt "{{! %s }}" s
+
   | Concat s ->
      List.iter (to_formatter fmt) s
 
@@ -127,6 +130,8 @@ let render_fmt (fmt : Format.formatter) (m : t) (js : Ezjsonm.t) =
     | Partial _ ->
        to_formatter fmt m
 
+    | Comment c -> ()
+
     | Concat templates ->
        List.iter (fun x -> render' x js) templates
 
@@ -147,3 +152,4 @@ let section n c = Section { name = n ; contents = c }
 let inverted_section n c = Inverted_section { name = n ; contents = c }
 let partial s = Partial s
 let concat t = Concat t
+let comment s = Comment s

--- a/lib/mustache.ml
+++ b/lib/mustache.ml
@@ -63,6 +63,7 @@ let to_string x =
   let b = Buffer.create 0 in
   let fmt = Format.formatter_of_buffer b in
   to_formatter fmt x ;
+  Format.pp_print_flush fmt () ;
   Buffer.contents b
 
 module Lookup = struct
@@ -106,8 +107,7 @@ end
 
 let render_fmt (fmt : Format.formatter) (m : t) (js : Ezjsonm.t) =
 
-  let rec render' m (js : Ezjsonm.value) =
-    match m with
+  let rec render' m (js : Ezjsonm.value) = match m with
 
     | Iter_var ->
        Format.pp_print_string fmt (Lookup.scalar js)
@@ -145,4 +145,5 @@ let render (m : t) (js : Ezjsonm.t) =
   let b = Buffer.create 0 in
   let fmt = Format.formatter_of_buffer b in
   render_fmt fmt m js ;
+  Format.pp_print_flush fmt () ;
   Buffer.contents b

--- a/lib/mustache.ml
+++ b/lib/mustache.ml
@@ -116,7 +116,7 @@ let render_fmt (fmt : Format.formatter) (m : t) (js : Ezjsonm.t) =
        Format.pp_print_string fmt s
 
     | Escaped key ->
-       Format.pp_print_string fmt (Lookup.str ~key js)
+       Format.pp_print_string fmt (escape_html (Lookup.str ~key js))
 
     | Unescaped key ->
        Format.pp_print_string fmt (Lookup.str ~key js)

--- a/lib/mustache.ml
+++ b/lib/mustache.ml
@@ -4,7 +4,6 @@ open MoreLabels
 include Mustache_types
 open Mustache_parser
 
-module Str = Re_str
 module List = ListLabels
 module String = StringLabels
 
@@ -25,19 +24,17 @@ let return = function
 let parse_lx = Mustache_parser.mustache Mustache_lexer.mustache
 let of_string s = s |> Lexing.from_string |> parse_lx
 
-let escape_table = [
-  ("&", "&amp;");
-  ("\"", "&quot;");
-  ("'", "&apos;");
-  (">", "&gt;");
-  ("<", "&lt;");
-] |> List.map ~f:(fun (re, v) -> (Str.regexp_string re, v))
-
-let escape_html init =
-  List.fold_left ~f:(fun s (search, replace) ->
-    Str.global_replace search replace s
-  ) ~init escape_table
-
+let escape_html s =
+  let b = Buffer.create (String.length s) in
+  String.iter ( function
+                | '&'  -> Buffer.add_string b "&amp;"
+                | '"'  -> Buffer.add_string b "&quot;"
+                | '\'' -> Buffer.add_string b "&apos;"
+                | '>'  -> Buffer.add_string b "&gt;"
+                | '<'  -> Buffer.add_string b "&lt;"
+                | c    -> Buffer.add_char b c
+              ) s ;
+  Buffer.contents b
 
 let rec to_string = function
   | Iter_var -> "{{.}}"

--- a/lib/mustache.ml
+++ b/lib/mustache.ml
@@ -15,12 +15,6 @@ module Infix = struct
   let (^) y x = Concat [x; y]
 end
 
-(* TODO: rename *)
-let return = function
-  | [] -> String ""
-  | [x] -> x
-  | xs -> Concat xs
-
 let parse_lx = Mustache_parser.mustache Mustache_lexer.mustache
 let of_string s = s |> Lexing.from_string |> parse_lx
 

--- a/lib/mustache.mli
+++ b/lib/mustache.mli
@@ -4,6 +4,7 @@ exception Invalid_template of string with sexp
 
 type t with sexp
 
+val parse_lx : Lexing.lexbuf -> t
 val of_string : string -> t
 val to_string : t -> string
 val render : t -> Ezjsonm.t -> string

--- a/lib/mustache.mli
+++ b/lib/mustache.mli
@@ -6,7 +6,11 @@ type t with sexp
 
 val parse_lx : Lexing.lexbuf -> t
 val of_string : string -> t
+
+val to_formatter : Format.formatter -> t -> unit
 val to_string : t -> string
+
+val render_fmt : Format.formatter -> t -> Ezjsonm.t -> unit
 val render : t -> Ezjsonm.t -> string
 
 (** Concatenate a list of mustache templates. Faster than concatenating

--- a/lib/mustache.mli
+++ b/lib/mustache.mli
@@ -54,5 +54,8 @@ val section : string -> t -> t
 (** [{{> box}}] *)
 val partial : string -> t
 
+(** [{{! this is a comment}}] *)
+val comment : string -> t
+
 (** Group a [t list] as a single [t]. *)
 val concat : t list -> t

--- a/lib/mustache.mli
+++ b/lib/mustache.mli
@@ -1,24 +1,58 @@
-(** A module for creating and rendering mustache templates in OCaml *)
+(** A module for creating and rendering mustache templates in OCaml. *)
 exception Invalid_param of string with sexp
 exception Invalid_template of string with sexp
 
 type t with sexp
 
+(** Read *)
 val parse_lx : Lexing.lexbuf -> t
 val of_string : string -> t
 
+(** [to_formatter fmt template] print a template as raw mustache to
+    the formatter [fmt].  *)
 val to_formatter : Format.formatter -> t -> unit
+
+(** [to_string template] uses [to_formatter] in order to return
+     a string representing the template as raw mustache.  *)
 val to_string : t -> string
 
+(** [render_fmt fmt template json] render [template], filling it
+    with data from [json], printing it to formatter [fmt]. *)
 val render_fmt : Format.formatter -> t -> Ezjsonm.t -> unit
+
+(** [render template json] use [render_fmt] to render [template]
+    with data from [json] and returns the resulting string. *)
 val render : t -> Ezjsonm.t -> string
 
-(** Concatenate a list of mustache templates. Faster than concatenating
-    them as strings. *)
-val concat : t list -> t
-
+(** Shortcut for concatening two templates pieces. *)
 module Infix : sig
   val (^) : t -> t -> t
 end
 
+(** Escape [&], ["\""], ['], [<] and [>]
+    character for html rendering. *)
 val escape_html : string -> string
+
+(** [{{.}}] *)
+val iter_var : t
+
+(** [<p>This is raw text.</p>] *)
+val raw : string -> t
+
+(** [{{name}}] *)
+val escaped : string -> t
+
+(** [{{{name}}}] *)
+val unescaped : string -> t
+
+(** [{{^person}} {{/person}}] *)
+val inverted_section : string -> t -> t
+
+(** [{{#person}} {{/person}}] *)
+val section : string -> t -> t
+
+(** [{{> box}}] *)
+val partial : string -> t
+
+(** Group a [t list] as a single [t]. *)
+val concat : t list -> t

--- a/lib/mustache_lexer.mll
+++ b/lib/mustache_lexer.mll
@@ -9,7 +9,7 @@ let id = ['a'-'z' 'A'-'Z' '_'] ['a'-'z' 'A'-'Z' '0'-'9' '_']+
 
 rule ident = parse
   | space '.' space { "." }
-  | space id space { String.trim (lexeme lexbuf) }
+  | space (id as x) space { x }
   | _ { raise (Invalid_template "Invalid section") }
 
 and mustache = parse

--- a/lib/mustache_lexer.mll
+++ b/lib/mustache_lexer.mll
@@ -21,7 +21,8 @@ and mustache = parse
   | "{{>"        { PARTIAL_START (ident lexbuf) }
   | "{{!"        { COMMENT_START }
   | "{{"         { ESCAPE_START (ident lexbuf) }
-  | space "}}"   { END }
+  | "}}}"        { UNESCAPE_END }
+  | "}}"         { END }
   | [^ '{' '}']* { RAW (lexeme lexbuf) }
   | ['{' '}']    { RAW (lexeme lexbuf) }
   | eof          { EOF }

--- a/lib/mustache_lexer.mll
+++ b/lib/mustache_lexer.mll
@@ -19,6 +19,7 @@ and mustache = parse
   | "{{^"        { SECTION_INVERT_START (ident lexbuf) }
   | "{{/"        { SECTION_END (ident lexbuf) }
   | "{{>"        { PARTIAL_START (ident lexbuf) }
+  | "{{!"        { COMMENT_START }
   | "{{"         { ESCAPE_START (ident lexbuf) }
   | space "}}"   { END }
   | [^ '{' '}']* { RAW (lexeme lexbuf) }

--- a/lib/mustache_parser.mly
+++ b/lib/mustache_parser.mly
@@ -19,6 +19,7 @@
 %token <string> SECTION_END
 %token <string> PARTIAL_START
 %token <string> UNESCAPE_START
+%token COMMENT_START
 %token UNESCAPE_END
 
 %token <string> RAW
@@ -38,6 +39,7 @@ mustache_element:
   | UNESCAPE_START_AMPERSAND ESCAPE_END { Unescaped $1 }
   | ESCAPE_START END { if $1 = "." then Iter_var else Escaped $1 }
   | PARTIAL_START END { Partial $1 }
+  | COMMENT_START RAW END { Comment $2 }
   | section { $1 }
 
 string:

--- a/lib/mustache_parser.mly
+++ b/lib/mustache_parser.mly
@@ -12,7 +12,6 @@
 %token EOF
 %token END
 %token <string> ESCAPE_START
-%token ESCAPE_END
 %token <string> UNESCAPE_START_AMPERSAND
 %token <string> SECTION_INVERT_START
 %token <string> SECTION_START
@@ -23,7 +22,6 @@
 %token UNESCAPE_END
 
 %token <string> RAW
-%token DOT
 
 %start mustache
 %type <Mustache_types.t> mustache
@@ -36,7 +34,7 @@ section:
 
 mustache_element:
   | UNESCAPE_START UNESCAPE_END { Unescaped $1 }
-  | UNESCAPE_START_AMPERSAND ESCAPE_END { Unescaped $1 }
+  | UNESCAPE_START_AMPERSAND END { Unescaped $1 }
   | ESCAPE_START END { if $1 = "." then Iter_var else Escaped $1 }
   | PARTIAL_START END { Partial $1 }
   | COMMENT_START RAW END { Comment $2 }

--- a/lib/mustache_types.ml
+++ b/lib/mustache_types.ml
@@ -9,6 +9,7 @@ type t =
   | Partial of string
   | Inverted_section of section
   | Concat of t list
+  | Comment of string
 and section = {
   name: string;
   contents: t;

--- a/lib/mustache_types.ml
+++ b/lib/mustache_types.ml
@@ -16,4 +16,3 @@ and section = {
 
 exception Invalid_param of string with sexp
 exception Invalid_template of string with sexp
-

--- a/lib_test/test_mustache.ml
+++ b/lib_test/test_mustache.ml
@@ -1,83 +1,73 @@
 open OUnit2
-open Printf
-open Sexplib.Std
+open Mustache
 
 module List = ListLabels
 module String = StringLabels
 
-let list_string_printer s =
-  "(" ^ (String.concat ~sep:";" s) ^ ")"
+(* [ ( Parser input, expected parser output,
+ *     [ (json data, expected rendering) ] ) ] *)
 
-let mustache_printer t =
-  t |> Mustache.sexp_of_t |> Sexplib.Sexp.to_string_hum
+let tests = [
+    ( "Hello {{ name }}!"
+    , concat [ raw "Hello " ; escaped "name" ; raw "!" ]
+    , [ ( `O ["name" , `String "testing"] , "Hello testing!" ) ] ) ;
 
-let string_printer x = x
+    ( "{{#bool}}there{{/bool}}"
+    , section "bool" (raw "there")
+    , [ ( `O ["bool", `Bool true], "there") ;
+        ( `O ["bool", `Bool false], "") ] ) ;
 
-let mustache1 _ =
-  let s = "Hello {{ name }}!" in
-  let tmpl = Mustache.of_string s in
-  let js = `O ["name", `String "testing"] in
-  assert_equal ~printer:string_printer "Hello testing!" (Mustache.render tmpl js)
+    ( "{{#implicit}}{{.}}.{{/implicit}}"
+    , section "implicit" (concat [ iter_var ; raw "." ])
+    ,  [ ( `O ["implicit", `A [`String "1" ;
+                               `String "2" ;
+                               `String "3"] ], "1.2.3.") ;
+         ( `O ["implicit", `A [] ], "") ] ) ;
 
-let mustache2 _ =
-  let tmpl = Mustache.of_string "{{#bool}}there{{/bool}}" in
-  let js' b = `O ["bool", `Bool b] in
-  assert_equal "there" (Mustache.render tmpl @@ js' true);
-  assert_equal "" (Mustache.render tmpl @@ js' false)
+    ( "{{#things}}{{v1}}-{{v2}}{{/things}}"
+    , section "things" (concat [ escaped "v1"
+                               ; raw "-"
+                               ; escaped "v2" ])
+    , [ ( `O [ "things" ,
+               `A [ `O [ ("v1", `String "1" ) ;
+                         ("v2", `String "one" ) ] ;
+                    `O [ ("v1", `String "2" ) ;
+                         ("v2", `String "two" ) ] ;
+                  ] ],
+          "1-one2-two" ) ] ) ;
 
-let mustache_section_list1 _ =
-  let tmpl = Mustache.of_string "{{#implicit}}{{.}}{{/implicit}}" in
-  let js' b =
-    let strs = b |> List.map ~f:(fun s -> `String s) in
-    `O ["implicit", `A strs]
-  in
-  assert_equal "" (Mustache.render tmpl @@ js' []);
-  assert_equal "onetwothree" (Mustache.render tmpl @@ js' ["one";"two";"three"])
+    ( "<style>div { border: {{border}}; }</style>"
+    , concat [ raw "<style>div " ;
+               raw "{" ;
+               raw " border: " ;
+               escaped "border" ;
+               raw "; " ;
+               raw "}" ;
+               raw "</style>" ]
+    , [ ( `O [ "border", `String "solid"],
+          "<style>div { border: solid; }</style>" ) ] ) ;
 
-let mustache_section_list2 _ =
-  let tmpl = Mustache.of_string "{{#things}}{{v1}}-{{v2}}{{/things}}" in
-  let js' pairs =
-    let dict (v1,v2) = `O [
-      ("v1", (`String v1));
-      ("v2", (`String v2))
-    ] in
-    let pairs = pairs |> List.map ~f:dict in
-    `O ["things", `A pairs]
-  in
-  assert_equal "" (Mustache.render tmpl @@ js' []);
-  let vs = [("one","1");("two","2")] in
-  assert_equal "one-1two-2" (Mustache.render tmpl @@ js' vs)
+  ]
 
-let test_scoped _ =
-  let tmpl = Mustache.of_string "{{#item}}{{content}}{{/item}}" in
-  let js = `O [ "item", `O [ "content", `String "internal"] ] in
-  assert_equal "internal" (Mustache.render tmpl js)
+let () =
 
-let test_html_escape1 _ =
-  let html = "<b>foo bar</b>" in
-  let escaped = Mustache.escape_html html in
-  assert_equal ~printer:(fun s -> s) "&lt;b&gt;foo bar&lt;/b&gt;" escaped
+  let assert_equal ?(printer=fun _ -> "") a b =
+    fun _ -> assert_equal ~printer a b in
 
-let test_single_braces _ =
-  let tmpl = Mustache.of_string "<style>div { border: {{border}}; }</style>" in
-  let js = `O [ "border", `String "solid"] in
-  assert_equal "<style>div { border: solid; }</style>" (Mustache.render tmpl js)
+  "Mustache test suite" >:::
 
-let test_sexp_conversion _ =
-  let s = Mustache.of_string "Hello {{ name }}" in
-  let s = s |> Mustache.sexp_of_t |> Sexplib.Sexp.to_string in
-  Printf.printf "Sexp: %s\n" s;
-  assert_bool "created sexp" true
+    (List.mapi
+       (fun i (input, expected_parsing, rendering_tests) ->
+        let template = Mustache.of_string input in
+        (Printf.sprintf "%d - parsing" i
+         >:: assert_equal expected_parsing template)
+        :: List.mapi (fun j (data, expected) ->
+                      (Printf.sprintf "%d - rendering (%d)" i j)
+                      >:: (Mustache.render template data
+                           |> assert_equal ~printer:(fun x -> x)
+                                           expected ) )
+                     rendering_tests )
+       tests
+     |> List.flatten)
 
-let suite =
-  "test mustache" >:::
-  [ "mustache1"               >:: mustache1
-  ; "bool sections"           >:: mustache2
-  ; "mustache section list 1" >:: mustache_section_list1
-  ; "mustache section list 2" >:: mustache_section_list2
-  ; "object scoped section"   >:: test_scoped
-  ; "test html escaping"      >:: test_html_escape1
-  ; "test single braces"      >:: test_single_braces
-  ; "test sexp conversion"    >:: test_sexp_conversion ]
-
-let () = run_test_tt_main suite
+  |> run_test_tt_main

--- a/lib_test/test_mustache.ml
+++ b/lib_test/test_mustache.ml
@@ -47,6 +47,12 @@ let tests = [
     , [ ( `O [ "border", `String "solid"],
           "<style>div { border: solid; }</style>" ) ] ) ;
 
+    ( "<h1>Today{{! ignore me }}.</h1>"
+    , concat [ raw "<h1>Today" ;
+               comment " ignore me " ;
+               raw ".</h1>" ]
+    , [ (`O [], "<h1>Today.</h1>") ] );
+
   ]
 
 let () =

--- a/lib_test/test_mustache.ml
+++ b/lib_test/test_mustache.ml
@@ -53,6 +53,17 @@ let tests = [
                raw ".</h1>" ]
     , [ (`O [], "<h1>Today.</h1>") ] );
 
+    ("{{ foo }}\
+      {{{ foo }}}\
+      {{& foo }}"
+    , concat [ escaped "foo" ;
+               unescaped "foo" ;
+               unescaped "foo" ]
+    , [ (`O [ "foo", `String "<b>bar</b>"],
+         "&lt;b&gt;bar&lt;/b&gt;\
+          <b>bar</b>\
+          <b>bar</b>" ) ] ) ;
+
   ]
 
 let () =


### PR DESCRIPTION
In this PR:
- Allow to use other source than string for template parsing
- Allow the use of formatter in order to print template and to render it
- Fixed parser and lexer (unescaped values)
- Added support for comments
- Functions to create a template programmatically
- Removed Re.str dependency
- Added some tests, removed some 

I think nothing should break...