### PR TITLE
section: change semantics to conform with other implementations

### DIFF
--- a/lib/mustache.ml
+++ b/lib/mustache.ml
@@ -133,10 +133,8 @@ module Lookup = struct
       match List.assoc key elems with
       (* php casting *)
       | `Null | `Float _ | `Bool false | `String "" -> `Bool false
-      | `Bool true -> `Bool true
-      | `A e -> `List e
-      | `O o -> `Scope (`O o)
-      | _ -> raise (Invalid_param ("section: invalid key: " ^ key))
+      | (`A _ | `O _) as js -> js
+      | _ -> js
 
   let inverted (js : Json.value) ~key =
     match js with
@@ -171,9 +169,9 @@ let render_fmt (fmt : Format.formatter) (m : t) (js : Json.t) =
     | Section s ->
       begin match Lookup.section js s.name with
       | `Bool false -> ()
-      | `Bool true -> render' s.contents js
-      | `List elems -> List.iter (render' s.contents) elems
-      | `Scope obj -> render' s.contents obj
+      | `Bool true  -> render' s.contents js
+      | `A contexts -> List.iter (render' s.contents) contexts
+      | context     -> render' s.contents context
       end
 
     | Partial _ ->


### PR DESCRIPTION
The previous implementation would throw an exception if the section did not correspond to an object, array, or boolean. This eliminated the possibility of performing truthy checks on the keys of the current context, and proceeding accordingly.

Now, if the key corresponds to a truthy value that is not an object or array, the test will succeed, using the current context as the context for the section. This is in line with the behavior of other impls,
namely [http://trymustache.com](http://trymustache.com).

This change is consistent with current tests.