### PR TITLE
dot: allow for escaped and unescaped dots

### DIFF
--- a/lib/mustache.mli
+++ b/lib/mustache.mli
@@ -46,13 +46,12 @@ val render : t -> Json.t -> string
     applied to the corresponding part.  The default for [f] is the identity
     function.
 
-    @param iter_var Called on each [{{.}}].
     @param string Applied to each literal part of the template.
     @param escaped Applied to ["name"] for occurrences of [{{name}}].
     @param unescaped Applied to ["name"] for occurrences of [{{{name}}}].
     @param partial Applied to ["box"] for occurrences of [{{> box}}].
     @param comment Applied to ["comment"] for occurrences of [{{! comment}}]. *)
-val fold : ?iter_var: ('a -> 'a) ->
+val fold :
 	   ?string: (string -> 'a -> 'a) ->
 	   ?escaped: (string -> 'a -> 'a) ->
 	   ?unescaped: (string -> 'a -> 'a) ->
@@ -72,9 +71,6 @@ end
 (** Escape [&], ["\""], ['], [<] and [>]
     character for html rendering. *)
 val escape_html : string -> string
-
-(** [{{.}}] *)
-val iter_var : t
 
 (** [<p>This is raw text.</p>] *)
 val raw : string -> t

--- a/lib/mustache_parser.mly
+++ b/lib/mustache_parser.mly
@@ -35,7 +35,7 @@ section:
 mustache_element:
   | UNESCAPE_START UNESCAPE_END { Unescaped $1 }
   | UNESCAPE_START_AMPERSAND END { Unescaped $1 }
-  | ESCAPE_START END { if $1 = "." then Iter_var else Escaped $1 }
+  | ESCAPE_START END { Escaped $1 }
   | PARTIAL_START END { Partial $1 }
   | COMMENT_START RAW END { Comment $2 }
   | section { $1 }

--- a/lib/mustache_types.ml
+++ b/lib/mustache_types.ml
@@ -1,5 +1,4 @@
 type t =
-  | Iter_var
   | String of string
   | Escaped of string
   | Section of section

--- a/lib_test/test_mustache.ml
+++ b/lib_test/test_mustache.ml
@@ -18,7 +18,7 @@ let tests = [
         ( `O ["bool", `Bool false], "") ] ) ;
 
     ( "{{#implicit}}{{.}}.{{/implicit}}"
-    , section "implicit" (concat [ iter_var ; raw "." ])
+    , section "implicit" (concat [ escaped "." ; raw "." ])
     ,  [ ( `O ["implicit", `A [`String "1" ;
                                `String "2" ;
                                `String "3"] ], "1.2.3.") ;


### PR DESCRIPTION
The previous code assumed that the dots would only appear in escaped blocks such as `{{.}}`. If a dot appeared in an unescaped block such as `{{& .}}` it would be treated as key as all other names would be.