### PR TITLE
fold: properly define fold function

### DIFF
--- a/lib/mustache.mli
+++ b/lib/mustache.mli
@@ -51,13 +51,14 @@ val render : ?strict:bool -> t -> Json.t -> string
     @param unescaped Applied to ["name"] for occurrences of [{{{name}}}].
     @param partial Applied to ["box"] for occurrences of [{{> box}}].
     @param comment Applied to ["comment"] for occurrences of [{{! comment}}]. *)
-val fold :
-	   ?string: (string -> 'a -> 'a) ->
-	   ?escaped: (string -> 'a -> 'a) ->
-	   ?unescaped: (string -> 'a -> 'a) ->
-	   ?partial: (string -> 'a -> 'a) ->
-	   ?comment: (string -> 'a -> 'a) ->
-	   t -> 'a -> 'a
+val fold : string: (string -> 'a) ->
+  section: (inverted:bool -> string -> 'a -> 'a) ->
+  escaped: (string -> 'a) ->
+  unescaped: (string -> 'a) ->
+  partial: (string -> 'a) ->
+  comment: (string -> 'a) ->
+  concat:('a list -> 'a) ->
+  t -> 'a
 
 val expand_partials : (string -> t) -> t -> t
 (** [expand_partials f template] is [template] with [f p] substituted for each


### PR DESCRIPTION
A fold for a type `t` should take a function for each constructor. The function is passed all the arguments of the corresponding constructor. If the constructor contains a value of type `t`, the "folded" t should be passed to the functions. A fold should only take an initial accumulator of it has a constructor that takes no arguments, like `[]` in the case of `list`s.