### PR TITLE
Adding Missing_section exception

### DIFF
--- a/lib/mustache.ml
+++ b/lib/mustache.ml
@@ -160,7 +160,7 @@ module Lookup = struct
         | (`A _ | `O _) as js -> js
         | _ -> js
       with Not_found ->
-        if strict then raise Not_found else `Bool false
+        if strict then raise (Missing_section key) else `Bool false
 
   let inverted (js : Json.value) ~key =
     match js with

--- a/lib/mustache.mli
+++ b/lib/mustache.mli
@@ -4,6 +4,7 @@ exception Invalid_template of string
 
 (** Raised when a missing variable in a template is not substituted *)
 exception Missing_variable of string
+exception Missing_section of string
 
 module Json : sig (** Compatible with Ezjsonm *)
   type value =

--- a/lib/mustache_types.ml
+++ b/lib/mustache_types.ml
@@ -36,3 +36,4 @@ and section = {
 exception Invalid_param of string
 exception Invalid_template of string
 exception Missing_variable of string
+exception Missing_section of string


### PR DESCRIPTION
The Not_found exception does not give the affected section name.