### PR TITLE
Switch to a menhir-generated parser (from a ocamlyacc-generated one)

### DIFF
--- a/_tags
+++ b/_tags
@@ -32,3 +32,5 @@ true: annot, bin_annot
 <lib_test/*.ml{,i,y}>: use_mustache
 <lib_test/mustache_cli.{native,byte}>: custom
 # OASIS_STOP
+
+true: use_menhir, explain

--- a/opam
+++ b/opam
@@ -29,6 +29,7 @@ build-test: [
 depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
+  "menhir" {build}
   "ounit" {test}
 ]
 


### PR DESCRIPTION
### Immediate benefits:

The parser got slightly refactored and is a bit cleaner/simpler:
- avoid "end-of-stream" conflicts, that were not reported by ocamlyacc but that menhir reports.
- use definitions from menhir's stdlib, e.g. list()

### Future benefits:

I plan on doing some parser refactoring, either for immediate fixes (eg currently the parsing of multiline comments is broken) or more involved changes in the route of handling most aspects of [this mustache spec](https://github.com/mustache/spec).

For that, having a menhir-based parser would be nicer.