### PR TITLE
Handle partials according to the spec

### DIFF
--- a/lib/mustache.mli
+++ b/lib/mustache.mli
@@ -29,7 +29,9 @@ type t =
   | Escaped of dotted_name
   | Section of section
   | Unescaped of dotted_name
-  | Partial of name
+  | Partial of (int * name)
+  (* The integer indicates the level of indentation that will be applied to the
+     partial contents. *)
   | Inverted_section of section
   | Concat of t list
   | Comment of string
@@ -85,7 +87,7 @@ val fold : string: (string -> 'a) ->
   section: (inverted:bool -> dotted_name -> 'a -> 'a) ->
   escaped: (dotted_name -> 'a) ->
   unescaped: (dotted_name -> 'a) ->
-  partial: (name -> 'a) ->
+  partial: (int -> name -> 'a) ->
   comment: (string -> 'a) ->
   concat:('a list -> 'a) ->
   t -> 'a
@@ -115,7 +117,7 @@ val inverted_section : dotted_name -> t -> t
 val section : dotted_name -> t -> t
 
 (** [{{> box}}] *)
-val partial : name -> t
+val partial : ?indent:int -> name -> t
 
 (** [{{! this is a comment}}] *)
 val comment : string -> t
@@ -135,7 +137,9 @@ module With_locations : sig
     | Escaped of dotted_name
     | Section of section
     | Unescaped of dotted_name
-    | Partial of name
+    | Partial of (int * name)
+    (* The integer indicates the level of indentation that will be applied to
+       the partial contents. *)
     | Inverted_section of section
     | Concat of t list
     | Comment of string
@@ -198,7 +202,7 @@ module With_locations : sig
     section: (loc:loc -> inverted:bool -> dotted_name -> 'a -> 'a) ->
     escaped: (loc:loc -> dotted_name -> 'a) ->
     unescaped: (loc:loc -> dotted_name -> 'a) ->
-    partial: (loc:loc -> name -> 'a) ->
+    partial: (loc:loc -> int -> name -> 'a) ->
     comment: (loc:loc -> string -> 'a) ->
     concat:(loc:loc -> 'a list -> 'a) ->
     t -> 'a
@@ -226,7 +230,7 @@ module With_locations : sig
   val section : loc:loc -> dotted_name -> t -> t
 
   (** [{{> box}}] *)
-  val partial : loc:loc -> name -> t
+  val partial : loc:loc -> ?indent:int -> name -> t
 
   (** [{{! this is a comment}}] *)
   val comment : loc:loc -> string -> t

--- a/lib/mustache_parser.mly
+++ b/lib/mustache_parser.mly
@@ -78,7 +78,12 @@ mustache_element:
   | elt = UNESCAPE_START UNESCAPE_END { with_loc $symbolstartpos $endpos (Unescaped elt) }
   | elt = UNESCAPE_START_AMPERSAND END { with_loc $symbolstartpos $endpos (Unescaped elt) }
   | elt = ESCAPE_START END { with_loc $symbolstartpos $endpos (Escaped elt) }
-  | elt = PARTIAL_START END { with_loc $symbolstartpos $endpos (Partial elt) }
+  | elt = PARTIAL_START END {
+      with_loc $symbolstartpos $endpos
+        (Partial { indent = fst elt;
+                   name = snd elt;
+                   contents = lazy None })
+    }
   | s = COMMENT { with_loc $symbolstartpos $endpos (Comment s) }
   | sec = section { sec }
   | s = RAW { with_loc $symbolstartpos $endpos (String s) }

--- a/lib/mustache_parser.mly
+++ b/lib/mustache_parser.mly
@@ -48,7 +48,7 @@
 %token <string list> SECTION_INVERT_START
 %token <string list> SECTION_START
 %token <string list> SECTION_END
-%token <string> PARTIAL_START
+%token <int * string> PARTIAL_START
 %token <string list> UNESCAPE_START
 %token <string> COMMENT
 %token UNESCAPE_END

--- a/lib/mustache_types.ml
+++ b/lib/mustache_types.ml
@@ -34,6 +34,8 @@ let string_of_dotted_name n =
   Format.asprintf "%a" pp_dotted_name n
 
 module Locs = struct
+  [@@@warning "-30"]
+
   type loc =
     { loc_start: Lexing.position;
       loc_end: Lexing.position }
@@ -43,35 +45,41 @@ module Locs = struct
     | Escaped of dotted_name
     | Section of section
     | Unescaped of dotted_name
-    | Partial of (int * name)
-    (* The integer indicates the level of indentation that will be applied to
-       the partial contents. *)
+    | Partial of partial
     | Inverted_section of section
     | Concat of t list
     | Comment of string
   and section =
     { name: dotted_name;
       contents: t }
+  and partial =
+    { indent: int;
+      name: name;
+      contents: t option Lazy.t }
   and t =
     { loc : loc;
       desc : desc }
 end
 
 module No_locs = struct
+  [@@@warning "-30"]
+
   type t =
     | String of string
     | Escaped of dotted_name
     | Section of section
     | Unescaped of dotted_name
-    | Partial of (int * name)
-    (* The integer indicates the level of indentation that will be applied to
-       the partial contents. *)
+    | Partial of partial
     | Inverted_section of section
     | Concat of t list
     | Comment of string
   and section =
     { name: dotted_name;
       contents: t }
+  and partial =
+    { indent: int;
+      name: name;
+      contents: t option Lazy.t }
 end
 
 exception Invalid_param of string

--- a/lib/mustache_types.ml
+++ b/lib/mustache_types.ml
@@ -43,7 +43,9 @@ module Locs = struct
     | Escaped of dotted_name
     | Section of section
     | Unescaped of dotted_name
-    | Partial of name
+    | Partial of (int * name)
+    (* The integer indicates the level of indentation that will be applied to
+       the partial contents. *)
     | Inverted_section of section
     | Concat of t list
     | Comment of string
@@ -61,7 +63,9 @@ module No_locs = struct
     | Escaped of dotted_name
     | Section of section
     | Unescaped of dotted_name
-    | Partial of name
+    | Partial of (int * name)
+    (* The integer indicates the level of indentation that will be applied to
+       the partial contents. *)
     | Inverted_section of section
     | Concat of t list
     | Comment of string

--- a/lib/mustache_types.ml
+++ b/lib/mustache_types.ml
@@ -74,3 +74,4 @@ exception Invalid_param of string
 exception Invalid_template of string
 exception Missing_variable of string
 exception Missing_section of string
+exception Missing_partial of string

--- a/lib_test/spec_mustache.ml
+++ b/lib_test/spec_mustache.ml
@@ -95,7 +95,7 @@ let specs = [
   "comments.json";
   "interpolation.json";
   "inverted.json";
-  "partials.json";
+  (* "partials.json"; *)
   "sections.json";
 ]
 

--- a/lib_test/spec_mustache.ml
+++ b/lib_test/spec_mustache.ml
@@ -95,7 +95,7 @@ let specs = [
   "comments.json";
   "interpolation.json";
   "inverted.json";
-  (* "partials.json"; *)
+  "partials.json";
   "sections.json";
 ]
 


### PR DESCRIPTION
This required changing the API a bit:

- The spec specifies that template rendering and partials substitution can mutually recurse: because of that, partial substitution is now done during rendering, not as a separate pass;
- The spec specifies that a template that fills a standalone partial must be rendered at the level of indentation of the partial. The AST now records the level of indentation of partials, and the information is used during the rendering.

As a side effect, all relevant tests of the spec now pass! 🎉  Not included: [delimiters](https://github.com/mustache/spec/blob/master/specs/delimiters.yml) which is madness, and [lambdas](https://github.com/mustache/spec/blob/master/specs/%7Elambdas.yml) which doesn't make sense. 