### PR TITLE
Remove {build} flag from menhir

### DIFF
--- a/opam
+++ b/opam
@@ -29,7 +29,7 @@ build-test: [
 depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "menhir" {build}
+  "menhir"
   "ounit" {test}
   "ezjsonm" {test}
 ]


### PR DESCRIPTION
When updating `menhir`, some packages depending on `mustache` are failing with the following error:
```
Error: Files /home/travis/.opam/system/lib/mustache/mustache.cmxa
       and /home/travis/.opam/system/lib/menhirLib/menhirLib.cmx
       make inconsistent assumptions over interface MenhirLib
```
Recompiling `mustache` seems to fix the issue.