### PR TITLE
Fix tests for use with ocaml 4.06.0 (safe-string)

### DIFF
--- a/lib_test/spec_mustache.ml
+++ b/lib_test/spec_mustache.ml
@@ -52,6 +52,7 @@ let j_of_data : J.value -> J.t = function
 let load_test_file f =
   let test_j =
     load_file (specs_directory ^/ f)
+    |> Bytes.to_string
     |> J.from_string
     |> J.value
   in


### PR DESCRIPTION
Hello, I needed this tiny fix in order to compile and run the tests with [OCaml 4.06](http://www.ocaml.org/releases/4.06.html). Without it, compiling the tests via `make test` resulted in the following error:

```
File "lib_test/spec_mustache.ml", line 55, characters 7-20:
Error: This expression has type string -> [> J.t ]
       but an expression was expected of type bytes -> 'a
       Type string is not compatible with type bytes
make: *** [test] Error 1
```

I assume this error is caused by the fact that safe-string is now on by default. I believe this fix is compatible with [OCaml 4.02](http://www.ocaml.org/releases/4.02.html) and up, but have not tested it.