### PR TITLE
Simplistic support for reporting lexing and parsing errors in template files

### DIFF
--- a/bin/mustache_cli.ml
+++ b/bin/mustache_cli.ml
@@ -1,6 +1,10 @@
 let apply_mustache json_data template_data =
   let env = Ezjsonm.from_string json_data
-  and tmpl = Mustache.of_string template_data
+  and tmpl =
+    try Mustache.of_string template_data
+    with Mustache.Parse_error err ->
+      Format.eprintf "%a@." Mustache.pp_error err;
+      exit 3
   in
   Mustache.render tmpl env |> print_endline
 

--- a/lib/mustache.ml
+++ b/lib/mustache.ml
@@ -142,13 +142,55 @@ let to_string x =
   Buffer.contents b
 
 (* Parsing: produces an ast with locations. *)
+type template_parse_error = {
+  lexbuf: Lexing.lexbuf;
+  kind: error_kind;
+}
+and error_kind = Parsing | Lexing of string
+
+exception Parse_error of template_parse_error
 
 let parse_lx (lexbuf: Lexing.lexbuf) : Locs.t =
-  MenhirLib.Convert.Simplified.traditional2revised
-    Mustache_parser.mustache
-    Mustache_lexer.(handle_standalone mustache lexbuf)
+  try
+    MenhirLib.Convert.Simplified.traditional2revised
+      Mustache_parser.mustache
+      Mustache_lexer.(handle_standalone mustache lexbuf)
+  with
+  | Mustache_lexer.Error msg ->
+    raise (Parse_error { lexbuf; kind = Lexing msg })
+  | Mustache_parser.Error ->
+    raise (Parse_error { lexbuf; kind = Parsing })
 
 let of_string s = parse_lx (Lexing.from_string s)
+
+let pp_error ppf { lexbuf; kind } =
+  let open Lexing in
+  let fname = lexbuf.lex_start_p.pos_fname in
+  let extract pos = (pos.pos_lnum, pos.pos_cnum - pos.pos_bol) in
+  let (start_line, start_col) = extract lexbuf.lex_start_p in
+  let (end_line, end_col) = extract lexbuf.lex_curr_p in
+  let p ppf = Format.fprintf ppf in
+  let pp_range ppf (start, end_) =
+    if start = end_ then
+      p ppf " %d" start
+    else
+      p ppf "s %d-%d" start end_
+  in
+  p ppf "@[";
+  begin if fname <> "" then
+    p ppf "File %S,@ l" fname
+  else
+    p ppf "L"
+  end;
+  p ppf "ine%a,@ character%a:@ "
+    pp_range (start_line, end_line)
+    pp_range (start_col, end_col)
+    ;
+  begin match kind with
+  | Parsing -> p ppf "syntax error"
+  | Lexing msg -> p ppf "%s" msg
+  end;
+  p ppf ".@]"
 
 (* Utility module, that helps looking up values in the json data during the
    rendering phase. *)

--- a/lib/mustache.ml
+++ b/lib/mustache.ml
@@ -192,6 +192,15 @@ let pp_error ppf { lexbuf; kind } =
   end;
   p ppf ".@]"
 
+let () =
+  Printexc.register_printer (function
+    | Parse_error err ->
+      let buf = Buffer.create 42 in
+      Format.fprintf (Format.formatter_of_buffer buf) "Mustache.Parse_error (%a)@." pp_error err;
+      Some (Buffer.contents buf)
+    | _ -> None
+  )
+
 (* Utility module, that helps looking up values in the json data during the
    rendering phase. *)
 

--- a/lib/mustache.mli
+++ b/lib/mustache.mli
@@ -43,9 +43,26 @@ and partial =
     name: name;
     contents: t option Lazy.t }
 
-(** Read *)
+(** Read template files; those function may raise Parse_error *)
+type template_parse_error
+exception Parse_error of template_parse_error
+
 val parse_lx : Lexing.lexbuf -> t
 val of_string : string -> t
+
+(** [pp_error fmt err] prints a human-readable description of
+    a parse error on the given formatter. The function does not
+    flush the formatter (in can you want to use it within boxes),
+    so you should remember to do it yourself.
+
+    {|
+      try ignore (Mustache.of_string "{{!")
+      with Mustache.Parse_error err ->
+        Format.eprintf "%a@." Mustache.pp_error err
+    |}
+*)
+val pp_error : Format.formatter -> template_parse_error -> unit
+
 
 (** [pp fmt template] print a template as raw mustache to
     the formatter [fmt].  *)


### PR DESCRIPTION
This PR is intended to make progress towards fixing #42 : indeed, if we want to use this for human-written templates, we should support the cases where the input is invalid and provide meaningful error messages.

The current PR does not implement meaningful error messages, but at least it documents the possibility of failure and gives the position where the error was detected by the lexer or parser.

It is not completely clear to me how much error-explanation cleverness you want in the main library. Arguably this would rather be the domain of "real applications" using the library down the chain, and the library could limit itself to giving information about the lexing/parsing state on error, to be formatted nicely by library users. This PR uses a different approach where the error type is abstract, and formatting is done by the library; this is more convenient in the short term, but less flexible in the long term.

Note: if we wanted good parsing error messages, we could not just use Menhir's support as-is, because currently most of the work is actually done by the lexer which "bundles" delimiters together with their payloads. So a first step would be to de-bundle the lexer, by instead emitting a token for the delimiter and one or several tokens for the payload, giving more grammar information to Menhir. (We could still keep some context-dependent lexing by having an explicit representation of the lexing state in the lexer: are we in-between delimiters?, etc.) This would be nice, but a much more invasive change than what I had the courage to do in a first PR.