### PR TITLE
 when lookup fail in the current context, go to parent contexts

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 * Improve parsing errors by adding locations (@gasche, #47)
 * Add `render_buf` to render templates directly to buffers (@gasche, #48)
+* When a lookup fails in the current context, lookup in parents contexts.
+  This should fix errors when using "{{#foo}}" for a scalar variable
+  'foo' to check that the variable exists.
+  (@gasche, #49)
 
 ### 3.1.0
 

--- a/lib_test/test_mustache.ml
+++ b/lib_test/test_mustache.ml
@@ -93,6 +93,16 @@ let tests = [
     , [ ( `O [ "a" , `A [ `O [ ("x", `Float 1.) ]; `O [ ("x", `Float 2.) ] ] ],
           "12" ) ] ) ;
 
+    ("{{#a}}{{.}}{{/a}}"
+    , section ["a"] (escaped [])
+    , [ ( `O [ "a" , `String "foo" ],
+          "foo" ) ] ) ;
+
+    ("{{#a}}{{a}}{{/a}}"
+    , section ["a"] (escaped ["a"])
+    , [ ( `O [ "a" , `String "foo" ],
+          "foo" ) ] ) ;
+
   ]
 
 let mkloc (lnum_s, bol_s, cnum_s, lnum_e, bol_e, cnum_e) =


### PR DESCRIPTION
(This PR is on top of #48 to avoid conflicts in the rendering implementation.)

There was a bug in a corner case of the variable-lookup semantics,
which is important because it corresponds to a fairly natural "if
variable exists" pattern (in non-strict-mode). Consider the following
example when `var` is mapped to a scalar value in the context:

    {{#var}} show the value {{var}} of the defined variable var {{/var}}

The current ocaml-mustache implementation will fail: when entiring the
`var` section, it would define the lookup context as the scalar value
itself, and any name lookup within the section would fail.

Instead the Mustache documentation and specification require that if
lookup in the current context fails (here the current context defines
no name), then "parent contexts" should be looked up; in particular,
the context before the section was entered, in which the lookup
succeeds.

> A {{name}} tag in a basic template will try to find the name key in
> the current context. If there is no name key, the parent contexts
> will be checked recursively. If the top context is reached and the
> name key is still not found, nothing will be rendered.

The present PR implements this "recursive lookup" semantics. Note that
falling back to parent contexts is *not* allowed in the middle of
resolving a dotted name (we find the right context for the first part
of the name, and then all subsequent lookups happen in
this context). This is explicitated in the Mustache specification,
interpolation.yml, example "Dotted Names - Broken Chain Resolution".

(It is unfortunate that the current specification does not cover the
edge case of scalar sections; I proposed a PR to fix this in
mustache/spec#114 .)

Note: an equivalent template would already work

    {{#var}} show the value {{.}} of the defined variable var {{/var}}

but it arguably results in less readable templates for non-experts.