### PR TITLE
Better errors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 ### 3.2.0
 
-* Improve parsing errors by adding locations (@gasche, #47)
+* Improve error messages (@gasche, #47 and #51)
+  Note: the exceptions raised by Mustache have changed, this breaks
+  compatibility for users that would catch and deconstruct existing
+  exceptions.
 * Add `render_buf` to render templates directly to buffers (@gasche, #48)
 * When a lookup fails in the current context, lookup in parents contexts.
   This should fix errors when using "{{#foo}}" for a scalar variable

--- a/bin/mustache_cli.ml
+++ b/bin/mustache_cli.ml
@@ -2,8 +2,9 @@ let apply_mustache json_data template_data =
   let env = Ezjsonm.from_string json_data
   and tmpl =
     try Mustache.of_string template_data
-    with Mustache.Parse_error err ->
-      Format.eprintf "%a@." Mustache.pp_error err;
+    with Mustache.Template_parse_error err ->
+      Format.eprintf "%a@."
+        Mustache.pp_template_parse_error err;
       exit 3
   in
   Mustache.render tmpl env |> print_endline

--- a/bin/mustache_cli.ml
+++ b/bin/mustache_cli.ml
@@ -3,10 +3,15 @@ module Mustache = struct
   include With_locations
 end
 
-let apply_mustache json_data template_data =
+let apply_mustache ~json_data ~template_filename ~template_data =
   let env = Ezjsonm.from_string json_data
   and tmpl =
-    try Mustache.of_string template_data
+    let lexbuf = Lexing.from_string template_data in
+    let () =
+      let open Lexing in
+      lexbuf.lex_curr_p <- { lexbuf.lex_curr_p with pos_fname = template_filename };
+    in
+    try Mustache.parse_lx lexbuf
     with Mustache.Template_parse_error err ->
       Format.eprintf "Template parse error:@\n%a@."
         Mustache.pp_template_parse_error err;
@@ -27,10 +32,10 @@ let load_file f =
   (Bytes.to_string s)
 
 let run json_filename template_filename =
-  let j = load_file json_filename
-  and t = load_file template_filename
+  let json_data = load_file json_filename
+  and template_data = load_file template_filename
   in
-  apply_mustache j t
+  apply_mustache ~json_data ~template_filename ~template_data
 
 let usage () =
   print_endline "Usage: mustache-cli json_filename template_filename"

--- a/bin/mustache_cli.ml
+++ b/bin/mustache_cli.ml
@@ -1,13 +1,22 @@
+module Mustache = struct
+  include Mustache
+  include With_locations
+end
+
 let apply_mustache json_data template_data =
   let env = Ezjsonm.from_string json_data
   and tmpl =
     try Mustache.of_string template_data
     with Mustache.Template_parse_error err ->
-      Format.eprintf "%a@."
+      Format.eprintf "Template parse error:@\n%a@."
         Mustache.pp_template_parse_error err;
       exit 3
   in
-  Mustache.render tmpl env |> print_endline
+  try Mustache.render tmpl env |> print_endline
+  with Mustache.Render_error err ->
+    Format.eprintf "Template render error:@\n%a@."
+      Mustache.pp_render_error err;
+    exit 2
 
 let load_file f =
   let ic = open_in f in

--- a/bin/test/errors/parsing-errors.t
+++ b/bin/test/errors/parsing-errors.t
@@ -98,7 +98,7 @@ Mismatch between section-start and section-end:
   $ mustache foo.json $PROBLEM
   Template parse error:
   File "foo-bar.mustache", lines 1-2, characters 23-0:
-  Mismatched section 'foo' with 'bar'.
+  Section mismatch: {{#foo}} is closed by {{/bar}}.
   [3]
 
   $ PROBLEM=foo-not-closed.mustache
@@ -113,5 +113,5 @@ Mismatch between section-start and section-end:
   $ mustache foo.json $PROBLEM
   Template parse error:
   File "wrong-nesting.mustache", lines 1-2, characters 41-0:
-  Mismatched section 'foo' with 'bar'.
+  Section mismatch: {{#foo}} is closed by {{/bar}}.
   [3]

--- a/bin/test/errors/parsing-errors.t
+++ b/bin/test/errors/parsing-errors.t
@@ -4,60 +4,70 @@ Delimiter problems:
   $ PROBLEM=no-closing-mustache.mustache
   $ echo "{{foo" > $PROBLEM
   $ mustache foo.json $PROBLEM
+  Template parse error:
   Line 2, character 0: syntax error.
   [3]
 
   $ PROBLEM=one-closing-mustache.mustache
   $ echo "{{foo}" > $PROBLEM
   $ mustache foo.json $PROBLEM
+  Template parse error:
   Lines 1-2, characters 6-0: syntax error.
   [3]
 
   $ PROBLEM=eof-before-variable.mustache
   $ echo "{{" > $PROBLEM
   $ mustache foo.json $PROBLEM
+  Template parse error:
   Line 2, character 0: ident expected.
   [3]
 
   $ PROBLEM=eof-before-section.mustache
   $ echo "{{#" > $PROBLEM
   $ mustache foo.json $PROBLEM
+  Template parse error:
   Line 2, character 0: ident expected.
   [3]
 
   $ PROBLEM=eof-before-section-end.mustache
   $ echo "{{#foo}} {{.}} {{/" > $PROBLEM
   $ mustache foo.json $PROBLEM
+  Template parse error:
   Line 2, character 0: ident expected.
   [3]
 
   $ PROBLEM=eof-before-inverted-section.mustache
   $ echo "{{^" > $PROBLEM
   $ mustache foo.json $PROBLEM
+  Template parse error:
   Line 2, character 0: ident expected.
   [3]
 
   $ PROBLEM=eof-before-unescape.mustache
   $ echo "{{{" > $PROBLEM
   $ mustache foo.json $PROBLEM
+  Template parse error:
   Line 2, character 0: ident expected.
   [3]
 
   $ PROBLEM=eof-before-unescape.mustache
   $ echo "{{&" > $PROBLEM
   $ mustache foo.json $PROBLEM
+  Template parse error:
   Line 2, character 0: ident expected.
   [3]
 
   $ PROBLEM=eof-before-partial.mustache
   $ echo "{{>" > $PROBLEM
   $ mustache foo.json $PROBLEM
+  Template parse error:
   Line 2, character 0: ident expected.
   [3]
 
   $ PROBLEM=eof-in-comment.mustache
   $ echo "{{! non-terminated comment" > $PROBLEM
   $ mustache foo.json $PROBLEM
+  Template parse error:
   Line 2, character 0: non-terminated comment.
   [3]
 
@@ -67,12 +77,14 @@ Mismatches between opening and closing mustaches:
   $ PROBLEM=two-three.mustache
   $ echo "{{ foo }}}" > $PROBLEM
   $ mustache foo.json $PROBLEM
+  Template parse error:
   Lines 1-2, characters 10-0: syntax error.
   [3]
 
   $ PROBLEM=three-two.mustache
   $ echo "{{{ foo }}" > $PROBLEM
   $ mustache foo.json $PROBLEM
+  Template parse error:
   Lines 1-2, characters 10-0: syntax error.
   [3]
 
@@ -82,17 +94,20 @@ Mismatch between section-start and section-end:
   $ PROBLEM=foo-bar.mustache
   $ echo "{{#foo}} {{.}} {{/bar}}" > $PROBLEM
   $ mustache foo.json $PROBLEM
+  Template parse error:
   Lines 1-2, characters 23-0: Mismatched section 'foo' with 'bar'.
   [3]
 
   $ PROBLEM=foo-not-closed.mustache
   $ echo "{{#foo}} {{.}} {{foo}}" > $PROBLEM
   $ mustache foo.json $PROBLEM
+  Template parse error:
   Line 2, character 0: syntax error.
   [3]
 
   $ PROBLEM=wrong-nesting.mustache
   $ echo "{{#bar}} {{#foo}} {{.}} {{/bar}} {{/foo}}" > $PROBLEM
   $ mustache foo.json $PROBLEM
+  Template parse error:
   Lines 1-2, characters 41-0: Mismatched section 'foo' with 'bar'.
   [3]

--- a/bin/test/errors/parsing-errors.t
+++ b/bin/test/errors/parsing-errors.t
@@ -82,8 +82,8 @@ Mismatch between section-start and section-end:
   $ PROBLEM=foo-bar.mustache
   $ echo "{{#foo}} {{.}} {{/bar}}" > $PROBLEM
   $ mustache foo.json $PROBLEM
-  Fatal error: exception Mustache_types.Invalid_template("Mismatched section foo with bar")
-  [2]
+  Lines 1-2, characters 23-0: Mismatched section foo with bar.
+  [3]
 
   $ PROBLEM=foo-not-closed.mustache
   $ echo "{{#foo}} {{.}} {{foo}}" > $PROBLEM
@@ -94,5 +94,5 @@ Mismatch between section-start and section-end:
   $ PROBLEM=wrong-nesting.mustache
   $ echo "{{#bar}} {{#foo}} {{.}} {{/bar}} {{/foo}}" > $PROBLEM
   $ mustache foo.json $PROBLEM
-  Fatal error: exception Mustache_types.Invalid_template("Mismatched section foo with bar")
-  [2]
+  Lines 1-2, characters 41-0: Mismatched section foo with bar.
+  [3]

--- a/bin/test/errors/parsing-errors.t
+++ b/bin/test/errors/parsing-errors.t
@@ -5,70 +5,72 @@ Delimiter problems:
   $ echo "{{foo" > $PROBLEM
   $ mustache foo.json $PROBLEM
   Template parse error:
-  Line 2, character 0: syntax error.
+  File "no-closing-mustache.mustache", line 2, character 0: syntax error.
   [3]
 
   $ PROBLEM=one-closing-mustache.mustache
   $ echo "{{foo}" > $PROBLEM
   $ mustache foo.json $PROBLEM
   Template parse error:
-  Lines 1-2, characters 6-0: syntax error.
+  File "one-closing-mustache.mustache", lines 1-2, characters 6-0:
+  syntax error.
   [3]
 
   $ PROBLEM=eof-before-variable.mustache
   $ echo "{{" > $PROBLEM
   $ mustache foo.json $PROBLEM
   Template parse error:
-  Line 2, character 0: ident expected.
+  File "eof-before-variable.mustache", line 2, character 0: ident expected.
   [3]
 
   $ PROBLEM=eof-before-section.mustache
   $ echo "{{#" > $PROBLEM
   $ mustache foo.json $PROBLEM
   Template parse error:
-  Line 2, character 0: ident expected.
+  File "eof-before-section.mustache", line 2, character 0: ident expected.
   [3]
 
   $ PROBLEM=eof-before-section-end.mustache
   $ echo "{{#foo}} {{.}} {{/" > $PROBLEM
   $ mustache foo.json $PROBLEM
   Template parse error:
-  Line 2, character 0: ident expected.
+  File "eof-before-section-end.mustache", line 2, character 0: ident expected.
   [3]
 
   $ PROBLEM=eof-before-inverted-section.mustache
   $ echo "{{^" > $PROBLEM
   $ mustache foo.json $PROBLEM
   Template parse error:
-  Line 2, character 0: ident expected.
+  File "eof-before-inverted-section.mustache", line 2, character 0:
+  ident expected.
   [3]
 
   $ PROBLEM=eof-before-unescape.mustache
   $ echo "{{{" > $PROBLEM
   $ mustache foo.json $PROBLEM
   Template parse error:
-  Line 2, character 0: ident expected.
+  File "eof-before-unescape.mustache", line 2, character 0: ident expected.
   [3]
 
   $ PROBLEM=eof-before-unescape.mustache
   $ echo "{{&" > $PROBLEM
   $ mustache foo.json $PROBLEM
   Template parse error:
-  Line 2, character 0: ident expected.
+  File "eof-before-unescape.mustache", line 2, character 0: ident expected.
   [3]
 
   $ PROBLEM=eof-before-partial.mustache
   $ echo "{{>" > $PROBLEM
   $ mustache foo.json $PROBLEM
   Template parse error:
-  Line 2, character 0: ident expected.
+  File "eof-before-partial.mustache", line 2, character 0: ident expected.
   [3]
 
   $ PROBLEM=eof-in-comment.mustache
   $ echo "{{! non-terminated comment" > $PROBLEM
   $ mustache foo.json $PROBLEM
   Template parse error:
-  Line 2, character 0: non-terminated comment.
+  File "eof-in-comment.mustache", line 2, character 0: non-terminated comment.
   [3]
 
 
@@ -78,14 +80,14 @@ Mismatches between opening and closing mustaches:
   $ echo "{{ foo }}}" > $PROBLEM
   $ mustache foo.json $PROBLEM
   Template parse error:
-  Lines 1-2, characters 10-0: syntax error.
+  File "two-three.mustache", lines 1-2, characters 10-0: syntax error.
   [3]
 
   $ PROBLEM=three-two.mustache
   $ echo "{{{ foo }}" > $PROBLEM
   $ mustache foo.json $PROBLEM
   Template parse error:
-  Lines 1-2, characters 10-0: syntax error.
+  File "three-two.mustache", lines 1-2, characters 10-0: syntax error.
   [3]
 
 
@@ -95,19 +97,21 @@ Mismatch between section-start and section-end:
   $ echo "{{#foo}} {{.}} {{/bar}}" > $PROBLEM
   $ mustache foo.json $PROBLEM
   Template parse error:
-  Lines 1-2, characters 23-0: Mismatched section 'foo' with 'bar'.
+  File "foo-bar.mustache", lines 1-2, characters 23-0:
+  Mismatched section 'foo' with 'bar'.
   [3]
 
   $ PROBLEM=foo-not-closed.mustache
   $ echo "{{#foo}} {{.}} {{foo}}" > $PROBLEM
   $ mustache foo.json $PROBLEM
   Template parse error:
-  Line 2, character 0: syntax error.
+  File "foo-not-closed.mustache", line 2, character 0: syntax error.
   [3]
 
   $ PROBLEM=wrong-nesting.mustache
   $ echo "{{#bar}} {{#foo}} {{.}} {{/bar}} {{/foo}}" > $PROBLEM
   $ mustache foo.json $PROBLEM
   Template parse error:
-  Lines 1-2, characters 41-0: Mismatched section 'foo' with 'bar'.
+  File "wrong-nesting.mustache", lines 1-2, characters 41-0:
+  Mismatched section 'foo' with 'bar'.
   [3]

--- a/bin/test/errors/parsing-errors.t
+++ b/bin/test/errors/parsing-errors.t
@@ -82,7 +82,7 @@ Mismatch between section-start and section-end:
   $ PROBLEM=foo-bar.mustache
   $ echo "{{#foo}} {{.}} {{/bar}}" > $PROBLEM
   $ mustache foo.json $PROBLEM
-  Lines 1-2, characters 23-0: Mismatched section foo with bar.
+  Lines 1-2, characters 23-0: Mismatched section 'foo' with 'bar'.
   [3]
 
   $ PROBLEM=foo-not-closed.mustache
@@ -94,5 +94,5 @@ Mismatch between section-start and section-end:
   $ PROBLEM=wrong-nesting.mustache
   $ echo "{{#bar}} {{#foo}} {{.}} {{/bar}} {{/foo}}" > $PROBLEM
   $ mustache foo.json $PROBLEM
-  Lines 1-2, characters 41-0: Mismatched section foo with bar.
+  Lines 1-2, characters 41-0: Mismatched section 'foo' with 'bar'.
   [3]

--- a/bin/test/errors/render-errors.t/run.t
+++ b/bin/test/errors/render-errors.t/run.t
@@ -27,49 +27,59 @@ one possible source of error, or both, or none.
 Invalid variable name:
 
   $ mustache reference.json missing-variable.mustache
-  Fatal error: exception Mustache.Render_error(_)
+  Fatal error: exception Mustache.Render_error:
+  Line 0, character -1: the variable 'na' is missing.
   [2]
 
   $ mustache missing-variable.json reference.mustache
-  Fatal error: exception Mustache.Render_error(_)
+  Fatal error: exception Mustache.Render_error:
+  Line 0, character -1: the variable 'data' is missing.
   [2]
 
 Invalid section name:
 
   $ mustache reference.json missing-section.mustache
-  Fatal error: exception Mustache.Render_error(_)
+  Fatal error: exception Mustache.Render_error:
+  Line 0, character -1: the section 'na' is missing.
   [2]
 
   $ mustache missing-section.json reference.mustache
-  Fatal error: exception Mustache.Render_error(_)
+  Fatal error: exception Mustache.Render_error:
+  Line 0, character -1: the section 'group' is missing.
   [2]
 
 Error in a dotted path foo.bar (one case for the first component, the other in the second).
 
   $ mustache reference.json invalid-dotted-name-1.mustache
-  Fatal error: exception Mustache.Render_error(_)
+  Fatal error: exception Mustache.Render_error:
+  Line 0, character -1: the variable 'gro' is missing.
   [2]
 
   $ mustache invalid-dotted-name-1.json reference.mustache
-  Fatal error: exception Mustache.Render_error(_)
+  Fatal error: exception Mustache.Render_error:
+  Line 0, character -1: the section 'group' is missing.
   [2]
 
   $ mustache reference.json invalid-dotted-name-2.mustache
-  Fatal error: exception Mustache.Render_error(_)
+  Fatal error: exception Mustache.Render_error:
+  Line 0, character -1: the variable 'group.fir' is missing.
   [2]
 
   $ mustache invalid-dotted-name-2.json reference.mustache
-  Fatal error: exception Mustache.Render_error(_)
+  Fatal error: exception Mustache.Render_error:
+  Line 0, character -1: the variable 'group.first' is missing.
   [2]
 
 Non-scalar used as a scalar:
 
   $ mustache reference.json non-scalar.mustache
-  Fatal error: exception Mustache.Render_error(_)
+  Fatal error: exception Mustache.Render_error:
+  Line 0, character -1: the value of 'list' is not a valid scalar.
   [2]
 
   $ mustache non-scalar.json reference.mustache
-  Fatal error: exception Mustache.Render_error(_)
+  Fatal error: exception Mustache.Render_error:
+  Line 0, character -1: the value of 'title' is not a valid scalar.
   [2]
 
 Missing partial (currently the CLI does not support any partial anyway):
@@ -78,5 +88,6 @@ Missing partial (currently the CLI does not support any partial anyway):
 in better `ls` output).
 
   $ mustache reference.json z-missing-partial.mustache
-  Fatal error: exception Mustache.Render_error(_)
+  Fatal error: exception Mustache.Render_error:
+  Line 0, character -1: the partial 'second' is missing.
   [2]

--- a/bin/test/errors/render-errors.t/run.t
+++ b/bin/test/errors/render-errors.t/run.t
@@ -28,58 +28,68 @@ Invalid variable name:
 
   $ mustache reference.json missing-variable.mustache
   Template render error:
-  Line 14, characters 40-46: the variable 'na' is missing.
+  File "missing-variable.mustache", line 14, characters 40-46:
+  the variable 'na' is missing.
   [2]
 
   $ mustache missing-variable.json reference.mustache
   Template render error:
-  Line 5, characters 4-12: the variable 'data' is missing.
+  File "reference.mustache", line 5, characters 4-12:
+  the variable 'data' is missing.
   [2]
 
 Invalid section name:
 
   $ mustache reference.json missing-section.mustache
   Template render error:
-  Line 14, characters 0-55: the section 'na' is missing.
+  File "missing-section.mustache", line 14, characters 0-55:
+  the section 'na' is missing.
   [2]
 
   $ mustache missing-section.json reference.mustache
   Template render error:
-  Lines 9-12, characters 0-10: the section 'group' is missing.
+  File "reference.mustache", lines 9-12, characters 0-10:
+  the section 'group' is missing.
   [2]
 
 Error in a dotted path foo.bar (one case for the first component, the other in the second).
 
   $ mustache reference.json invalid-dotted-name-1.mustache
   Template render error:
-  Line 10, characters 2-15: the variable 'gro' is missing.
+  File "invalid-dotted-name-1.mustache", line 10, characters 2-15:
+  the variable 'gro' is missing.
   [2]
 
   $ mustache invalid-dotted-name-1.json reference.mustache
   Template render error:
-  Lines 9-12, characters 0-10: the section 'group' is missing.
+  File "reference.mustache", lines 9-12, characters 0-10:
+  the section 'group' is missing.
   [2]
 
   $ mustache reference.json invalid-dotted-name-2.mustache
   Template render error:
-  Line 10, characters 2-15: the variable 'group.fir' is missing.
+  File "invalid-dotted-name-2.mustache", line 10, characters 2-15:
+  the variable 'group.fir' is missing.
   [2]
 
   $ mustache invalid-dotted-name-2.json reference.mustache
   Template render error:
-  Line 10, characters 2-17: the variable 'group.first' is missing.
+  File "reference.mustache", line 10, characters 2-17:
+  the variable 'group.first' is missing.
   [2]
 
 Non-scalar used as a scalar:
 
   $ mustache reference.json non-scalar.mustache
   Template render error:
-  Line 4, characters 0-8: the value of 'list' is not a valid scalar.
+  File "non-scalar.mustache", line 4, characters 0-8:
+  the value of 'list' is not a valid scalar.
   [2]
 
   $ mustache non-scalar.json reference.mustache
   Template render error:
-  Line 1, characters 7-16: the value of 'title' is not a valid scalar.
+  File "reference.mustache", line 1, characters 7-16:
+  the value of 'title' is not a valid scalar.
   [2]
 
 Missing partial (currently the CLI does not support any partial anyway):
@@ -89,5 +99,6 @@ in better `ls` output).
 
   $ mustache reference.json z-missing-partial.mustache
   Template render error:
-  Line 11, characters 2-13: the partial 'second' is missing.
+  File "z-missing-partial.mustache", line 11, characters 2-13:
+  the partial 'second' is missing.
   [2]

--- a/bin/test/errors/render-errors.t/run.t
+++ b/bin/test/errors/render-errors.t/run.t
@@ -27,49 +27,49 @@ one possible source of error, or both, or none.
 Invalid variable name:
 
   $ mustache reference.json missing-variable.mustache
-  Fatal error: exception Mustache_types.Missing_variable("na")
+  Fatal error: exception Mustache.Render_error(_)
   [2]
 
   $ mustache missing-variable.json reference.mustache
-  Fatal error: exception Mustache_types.Missing_variable("data")
+  Fatal error: exception Mustache.Render_error(_)
   [2]
 
 Invalid section name:
 
   $ mustache reference.json missing-section.mustache
-  Fatal error: exception Mustache_types.Missing_section("na")
+  Fatal error: exception Mustache.Render_error(_)
   [2]
 
   $ mustache missing-section.json reference.mustache
-  Fatal error: exception Mustache_types.Missing_section("group")
+  Fatal error: exception Mustache.Render_error(_)
   [2]
 
 Error in a dotted path foo.bar (one case for the first component, the other in the second).
 
   $ mustache reference.json invalid-dotted-name-1.mustache
-  Fatal error: exception Mustache_types.Missing_variable("gro")
+  Fatal error: exception Mustache.Render_error(_)
   [2]
 
   $ mustache invalid-dotted-name-1.json reference.mustache
-  Fatal error: exception Mustache_types.Missing_section("group")
+  Fatal error: exception Mustache.Render_error(_)
   [2]
 
   $ mustache reference.json invalid-dotted-name-2.mustache
-  Fatal error: exception Mustache_types.Missing_variable("fir")
+  Fatal error: exception Mustache.Render_error(_)
   [2]
 
   $ mustache invalid-dotted-name-2.json reference.mustache
-  Fatal error: exception Mustache_types.Missing_variable("first")
+  Fatal error: exception Mustache.Render_error(_)
   [2]
 
 Non-scalar used as a scalar:
 
   $ mustache reference.json non-scalar.mustache
-  Fatal error: exception Mustache_types.Invalid_param("Lookup.scalar: not a scalar")
+  Fatal error: exception Mustache.Render_error(_)
   [2]
 
   $ mustache non-scalar.json reference.mustache
-  Fatal error: exception Mustache_types.Invalid_param("Lookup.scalar: not a scalar")
+  Fatal error: exception Mustache.Render_error(_)
   [2]
 
 Missing partial (currently the CLI does not support any partial anyway):
@@ -78,5 +78,5 @@ Missing partial (currently the CLI does not support any partial anyway):
 in better `ls` output).
 
   $ mustache reference.json z-missing-partial.mustache
-  Fatal error: exception Mustache_types.Missing_partial("second")
+  Fatal error: exception Mustache.Render_error(_)
   [2]

--- a/bin/test/errors/render-errors.t/run.t
+++ b/bin/test/errors/render-errors.t/run.t
@@ -27,59 +27,59 @@ one possible source of error, or both, or none.
 Invalid variable name:
 
   $ mustache reference.json missing-variable.mustache
-  Fatal error: exception Mustache.Render_error:
-  Line 0, character -1: the variable 'na' is missing.
+  Template render error:
+  Line 14, characters 40-46: the variable 'na' is missing.
   [2]
 
   $ mustache missing-variable.json reference.mustache
-  Fatal error: exception Mustache.Render_error:
-  Line 0, character -1: the variable 'data' is missing.
+  Template render error:
+  Line 5, characters 4-12: the variable 'data' is missing.
   [2]
 
 Invalid section name:
 
   $ mustache reference.json missing-section.mustache
-  Fatal error: exception Mustache.Render_error:
-  Line 0, character -1: the section 'na' is missing.
+  Template render error:
+  Line 14, characters 0-55: the section 'na' is missing.
   [2]
 
   $ mustache missing-section.json reference.mustache
-  Fatal error: exception Mustache.Render_error:
-  Line 0, character -1: the section 'group' is missing.
+  Template render error:
+  Lines 9-12, characters 0-10: the section 'group' is missing.
   [2]
 
 Error in a dotted path foo.bar (one case for the first component, the other in the second).
 
   $ mustache reference.json invalid-dotted-name-1.mustache
-  Fatal error: exception Mustache.Render_error:
-  Line 0, character -1: the variable 'gro' is missing.
+  Template render error:
+  Line 10, characters 2-15: the variable 'gro' is missing.
   [2]
 
   $ mustache invalid-dotted-name-1.json reference.mustache
-  Fatal error: exception Mustache.Render_error:
-  Line 0, character -1: the section 'group' is missing.
+  Template render error:
+  Lines 9-12, characters 0-10: the section 'group' is missing.
   [2]
 
   $ mustache reference.json invalid-dotted-name-2.mustache
-  Fatal error: exception Mustache.Render_error:
-  Line 0, character -1: the variable 'group.fir' is missing.
+  Template render error:
+  Line 10, characters 2-15: the variable 'group.fir' is missing.
   [2]
 
   $ mustache invalid-dotted-name-2.json reference.mustache
-  Fatal error: exception Mustache.Render_error:
-  Line 0, character -1: the variable 'group.first' is missing.
+  Template render error:
+  Line 10, characters 2-17: the variable 'group.first' is missing.
   [2]
 
 Non-scalar used as a scalar:
 
   $ mustache reference.json non-scalar.mustache
-  Fatal error: exception Mustache.Render_error:
-  Line 0, character -1: the value of 'list' is not a valid scalar.
+  Template render error:
+  Line 4, characters 0-8: the value of 'list' is not a valid scalar.
   [2]
 
   $ mustache non-scalar.json reference.mustache
-  Fatal error: exception Mustache.Render_error:
-  Line 0, character -1: the value of 'title' is not a valid scalar.
+  Template render error:
+  Line 1, characters 7-16: the value of 'title' is not a valid scalar.
   [2]
 
 Missing partial (currently the CLI does not support any partial anyway):
@@ -88,6 +88,6 @@ Missing partial (currently the CLI does not support any partial anyway):
 in better `ls` output).
 
   $ mustache reference.json z-missing-partial.mustache
-  Fatal error: exception Mustache.Render_error:
-  Line 0, character -1: the partial 'second' is missing.
+  Template render error:
+  Line 11, characters 2-13: the partial 'second' is missing.
   [2]

--- a/lib/mustache.ml
+++ b/lib/mustache.ml
@@ -177,7 +177,7 @@ let parse_lx (lexbuf: Lexing.lexbuf) : Locs.t =
 
 let of_string s = parse_lx (Lexing.from_string s)
 
-let pp_template_parse_error ppf { loc; kind } =
+let pp_loc ppf loc =
   let open Lexing in
   let fname = loc.loc_start.pos_fname in
   let extract pos = (pos.pos_lnum, pos.pos_cnum - pos.pos_bol) in
@@ -196,10 +196,13 @@ let pp_template_parse_error ppf { loc; kind } =
   else
     p ppf "L"
   end;
-  p ppf "ine%a,@ character%a:@ "
+  p ppf "ine%a,@ character%a"
     pp_range (start_line, end_line)
     pp_range (start_col, end_col)
-    ;
+
+let pp_template_parse_error ppf { loc; kind } =
+  let p ppf = Format.fprintf ppf in
+  p ppf "@[%a:@ " pp_loc loc;
   begin match kind with
   | Lexing msg ->
     p ppf "%s" msg

--- a/lib/mustache.ml
+++ b/lib/mustache.ml
@@ -219,7 +219,7 @@ let pp_template_parse_error ppf ({ loc; kind; } : template_parse_error) =
   | Parsing ->
     p ppf "syntax error"
   | Mismatched_section { start_name; end_name } ->
-    p ppf "Mismatched section '%a' with '%a'"
+    p ppf "Section mismatch: {{#%a}} is closed by {{/%a}}"
       pp_dotted_name start_name
       pp_dotted_name end_name
   end;

--- a/lib/mustache.mli
+++ b/lib/mustache.mli
@@ -84,6 +84,8 @@ type render_error = { loc: loc; kind : render_error_kind }
 
 exception Render_error of render_error
 
+val pp_render_error : Format.formatter -> render_error -> unit
+
 (** [render_fmt fmt template json] renders [template], filling it
     with data from [json], printing it to formatter [fmt].
 

--- a/lib/mustache.mli
+++ b/lib/mustache.mli
@@ -74,11 +74,13 @@ val to_string : t -> string
 
 
 (** Render templates; those functions may raise [Render_error]. *)
-type render_error =
-  | Invalid_param of string
-  | Missing_variable of string
-  | Missing_section of string
-  | Missing_partial of string
+type render_error_kind =
+  | Invalid_param of { name: dotted_name; expected_form: string; }
+  | Missing_variable of { name: dotted_name; }
+  | Missing_section of { name: dotted_name; }
+  | Missing_partial of { name: name; }
+
+type render_error = { loc: loc; kind : render_error_kind }
 
 exception Render_error of render_error
 

--- a/lib/mustache.mli
+++ b/lib/mustache.mli
@@ -36,6 +36,10 @@ and partial =
     name: name;
     contents: t option Lazy.t }
 
+type loc =
+    { loc_start: Lexing.position;
+      loc_end: Lexing.position }
+
 (** Read template files; those function may raise [Template_parse_error]. *)
 type template_parse_error
 exception Template_parse_error of template_parse_error
@@ -172,9 +176,9 @@ val concat : t list -> t
 (** Variant of the [t] mustache datatype which includes source-file locations,
     and associated functions. *)
 module With_locations : sig
-  type loc =
-    { loc_start: Lexing.position;
-      loc_end: Lexing.position }
+  (* this type has been moved out,
+     keep an alias for backward-compatibility *)
+  type nonrec loc = loc = { loc_start: Lexing.position; loc_end: Lexing.position }
 
   type desc =
     | String of string

--- a/lib/mustache_parser.mly
+++ b/lib/mustache_parser.mly
@@ -23,6 +23,7 @@
 %{
   open Mustache_types
   open Mustache_types.Locs
+
   let parse_section start_s end_s contents =
     if start_s = end_s
     then { contents; name=start_s }

--- a/lib/mustache_parser.mly
+++ b/lib/mustache_parser.mly
@@ -24,16 +24,10 @@
   open Mustache_types
   open Mustache_types.Locs
 
-  let parse_section start_s end_s contents =
-    if start_s = end_s
-    then { contents; name=start_s }
-    else
-      let msg =
-        Printf.sprintf "Mismatched section %s with %s"
-                       (string_of_dotted_name start_s)
-                       (string_of_dotted_name end_s)
-      in
-      raise (Invalid_template msg)
+  let parse_section start_name end_name contents =
+    if start_name <> end_name then
+      raise (Mismatched_section { start_name; end_name });
+    { contents; name = start_name }
 
   let with_loc (startpos, endpos) desc =
     let loc =

--- a/lib/mustache_types.ml
+++ b/lib/mustache_types.ml
@@ -82,8 +82,6 @@ module No_locs = struct
       contents: t option Lazy.t }
 end
 
-exception Invalid_param of string
+(* this exception is used internally in the parser,
+   never exposed to users *)
 exception Invalid_template of string
-exception Missing_variable of string
-exception Missing_section of string
-exception Missing_partial of string

--- a/lib/mustache_types.ml
+++ b/lib/mustache_types.ml
@@ -23,6 +23,10 @@
 type name = string
 type dotted_name = string list
 
+type loc =
+  { loc_start: Lexing.position;
+    loc_end: Lexing.position }
+
 let pp_dotted_name fmt = function
   | [] ->
     Format.fprintf fmt "."
@@ -35,10 +39,6 @@ let string_of_dotted_name n =
 
 module Locs = struct
   [@@@warning "-30"]
-
-  type loc =
-    { loc_start: Lexing.position;
-      loc_end: Lexing.position }
 
   type desc =
     | String of string
@@ -84,4 +84,7 @@ end
 
 (* this exception is used internally in the parser,
    never exposed to users *)
-exception Invalid_template of string
+exception Mismatched_section of {
+  start_name: dotted_name;
+  end_name: dotted_name;
+}


### PR DESCRIPTION
This PR is on top of #50, it adds more informative arguments to render-time exceptions and transforms them into better error messages.

Before:

```
Fatal error: exception Mustache_types.Missing_variable("d")
```

After:
```
Template render error:
File "test.mustache", line 2, characters 7-12: the variable d is missing.
```

This is a breaking change as the exception types have changed, but the change only affects users who are not catching and inspecting Mustache exceptions.

However, good error locations are only available if people used the `With_locations` modules. If you want a 4.0 release for a breaking change, now may also be a good time to make `With_locations` the default.
(I have some other features planned for the next few days, so I am not suggesting to make a new release right now. But I'm interested in having an idea of the amount of breakage that @rgrinberg would consider acceptable for a future release.)

@rgrinberg I would have liked to add `cram`-style tests for this PR (I'm thinking of having `bin/test` where each error message is tested by cramming the binary), but this requires upgrading `dune-lang` to 2.7; I tried this and it complains that `action` was deleted some time ago and I should rewrite some other tests in a way that I don't really understand. When you have time, do you think that you could take care of upgrading dune-lang to 2.x for the project?