### PR TITLE
Track open sections

### DIFF
--- a/bin/test/errors/render-errors.t/run.t
+++ b/bin/test/errors/render-errors.t/run.t
@@ -29,13 +29,13 @@ Invalid variable name:
   $ mustache reference.json missing-variable.mustache
   Template render error:
   File "missing-variable.mustache", line 14, characters 40-46:
-  the variable 'na' is missing.
+  the variable 'na' is missing (inside section 'name').
   [2]
 
   $ mustache missing-variable.json reference.mustache
   Template render error:
   File "reference.mustache", line 5, characters 4-12:
-  the variable 'data' is missing.
+  the variable 'data' is missing (inside section 'list').
   [2]
 
 Invalid section name:
@@ -57,7 +57,7 @@ Error in a dotted path foo.bar (one case for the first component, the other in t
   $ mustache reference.json invalid-dotted-name-1.mustache
   Template render error:
   File "invalid-dotted-name-1.mustache", line 10, characters 2-15:
-  the variable 'gro' is missing.
+  the variable 'gro' is missing (inside section 'group').
   [2]
 
   $ mustache invalid-dotted-name-1.json reference.mustache
@@ -69,13 +69,13 @@ Error in a dotted path foo.bar (one case for the first component, the other in t
   $ mustache reference.json invalid-dotted-name-2.mustache
   Template render error:
   File "invalid-dotted-name-2.mustache", line 10, characters 2-15:
-  the variable 'group.fir' is missing.
+  the variable 'group.fir' is missing (inside section 'group').
   [2]
 
   $ mustache invalid-dotted-name-2.json reference.mustache
   Template render error:
   File "reference.mustache", line 10, characters 2-17:
-  the variable 'group.first' is missing.
+  the variable 'group.first' is missing (inside section 'group').
   [2]
 
 Non-scalar used as a scalar:
@@ -100,5 +100,5 @@ in better `ls` output).
   $ mustache reference.json z-missing-partial.mustache
   Template render error:
   File "z-missing-partial.mustache", line 11, characters 2-13:
-  the partial 'second' is missing.
+  the partial 'second' is missing (inside section 'group').
   [2]

--- a/lib/mustache.mli
+++ b/lib/mustache.mli
@@ -40,6 +40,14 @@ type loc =
     { loc_start: Lexing.position;
       loc_end: Lexing.position }
 
+(** Mustache "contexts" are the environment in which
+    names are looked up, determined by which sections
+    have been opened at this point in the template. *)
+module Contexts : sig
+  type t
+  val explain : t -> string option
+end
+
 (** Read template files; those function may raise [Template_parse_error]. *)
 type template_parse_error
 exception Template_parse_error of template_parse_error
@@ -80,7 +88,7 @@ type render_error_kind =
   | Missing_section of { name: dotted_name; }
   | Missing_partial of { name: name; }
 
-type render_error = { loc: loc; kind : render_error_kind }
+type render_error = { loc: loc; ctxs: Contexts.t; kind : render_error_kind }
 
 exception Render_error of render_error
 


### PR DESCRIPTION
This PR is on top of #51 (sorry about the stacking...). It adds information about which sections are currently open in the error message.

Example:

```
$ cat test.json
{
  "list": [
    { "header": {} }
  ]
}
$ cat test.mustache
{{#list}}
  {{#header}} {{title}} {{/header}}
{{/list}}
```

Before:

```
Template render error:
File "test.mustache", line 2, characters 14-23: the variable title is missing.
```

After:

```
Template render error:
File "test.mustache", line 2, characters 14-23: the variable title is missing
(sections opened: list, header).
```

I separated this change from #50 because I am not sure people like it, and I am not sure about the wording.
- when sections are open, is "(sections opened: ...)" a good message? I also considered, for example, "(in sections: ...)".
- when no sections are open, I currently use "(no sections opened)", should I not print anything instead? 
- the format as-is does not extend to partials (we don't track inside which partial we are), should it? (If partials are implemented by file inclusion, the filename may suffice to get the information.) I vote to leave partials out for now, it can easily be added later.