### PR TITLE
don't print json

### DIFF
--- a/bin/mustache_cli.ml
+++ b/bin/mustache_cli.ml
@@ -20,7 +20,6 @@ let run json_filename template_filename =
   let j = load_file json_filename
   and t = load_file template_filename
   in
-  (* print_endline j; *)
   apply_mustache j t
 
 let usage () =

--- a/bin/mustache_cli.ml
+++ b/bin/mustache_cli.ml
@@ -20,7 +20,7 @@ let run json_filename template_filename =
   let j = load_file json_filename
   and t = load_file template_filename
   in
-  print_endline j;
+  (* print_endline j; *)
   apply_mustache j t
 
 let usage () =


### PR DESCRIPTION
Following the discussion here: https://github.com/rgrinberg/ocaml-mustache/issues/43
and here: https://github.com/rgrinberg/ocaml-mustache/pull/44
this pull-request removes the behavior under which the command-line ``mustache_cli``
first emits the JSON file before printing the result.