### PR TITLE
Cram tests for all error cases 

### DIFF
--- a/bin/test/errors/dune
+++ b/bin/test/errors/dune
@@ -1,0 +1,2 @@
+(cram
+ (deps %{bin:mustache}))

--- a/bin/test/errors/json-errors.t
+++ b/bin/test/errors/json-errors.t
@@ -1,0 +1,13 @@
+  $ touch empty.json
+  $ echo '{ "foo": "Foo"; "bar": "Bar" }' > invalid.json
+  $ echo '{{foo}}' > foo.mustache
+
+Empty json file:
+  $ mustache empty.json foo.mustache
+  Fatal error: exception Ezjsonm.Parse_error(870828711, "JSON.of_buffer expected JSON text (JSON value)")
+  [2]
+
+Invalid json file:
+  $ mustache invalid.json foo.mustache
+  Fatal error: exception Ezjsonm.Parse_error(870828711, "JSON.of_buffer expected value separator or object end (',' or '}')")
+  [2]

--- a/bin/test/errors/parsing-errors.t
+++ b/bin/test/errors/parsing-errors.t
@@ -1,0 +1,98 @@
+  $ echo '{ "foo": "Foo"}' > foo.json
+
+Delimiter problems:
+  $ PROBLEM=no-closing-mustache.mustache
+  $ echo "{{foo" > $PROBLEM
+  $ mustache foo.json $PROBLEM
+  Line 2, character 0: syntax error.
+  [3]
+
+  $ PROBLEM=one-closing-mustache.mustache
+  $ echo "{{foo}" > $PROBLEM
+  $ mustache foo.json $PROBLEM
+  Lines 1-2, characters 6-0: syntax error.
+  [3]
+
+  $ PROBLEM=eof-before-variable.mustache
+  $ echo "{{" > $PROBLEM
+  $ mustache foo.json $PROBLEM
+  Line 2, character 0: ident expected.
+  [3]
+
+  $ PROBLEM=eof-before-section.mustache
+  $ echo "{{#" > $PROBLEM
+  $ mustache foo.json $PROBLEM
+  Line 2, character 0: ident expected.
+  [3]
+
+  $ PROBLEM=eof-before-section-end.mustache
+  $ echo "{{#foo}} {{.}} {{/" > $PROBLEM
+  $ mustache foo.json $PROBLEM
+  Line 2, character 0: ident expected.
+  [3]
+
+  $ PROBLEM=eof-before-inverted-section.mustache
+  $ echo "{{^" > $PROBLEM
+  $ mustache foo.json $PROBLEM
+  Line 2, character 0: ident expected.
+  [3]
+
+  $ PROBLEM=eof-before-unescape.mustache
+  $ echo "{{{" > $PROBLEM
+  $ mustache foo.json $PROBLEM
+  Line 2, character 0: ident expected.
+  [3]
+
+  $ PROBLEM=eof-before-unescape.mustache
+  $ echo "{{&" > $PROBLEM
+  $ mustache foo.json $PROBLEM
+  Line 2, character 0: ident expected.
+  [3]
+
+  $ PROBLEM=eof-before-partial.mustache
+  $ echo "{{>" > $PROBLEM
+  $ mustache foo.json $PROBLEM
+  Line 2, character 0: ident expected.
+  [3]
+
+  $ PROBLEM=eof-in-comment.mustache
+  $ echo "{{! non-terminated comment" > $PROBLEM
+  $ mustache foo.json $PROBLEM
+  Line 2, character 0: non-terminated comment.
+  [3]
+
+
+Mismatches between opening and closing mustaches:
+
+  $ PROBLEM=two-three.mustache
+  $ echo "{{ foo }}}" > $PROBLEM
+  $ mustache foo.json $PROBLEM
+  Lines 1-2, characters 10-0: syntax error.
+  [3]
+
+  $ PROBLEM=three-two.mustache
+  $ echo "{{{ foo }}" > $PROBLEM
+  $ mustache foo.json $PROBLEM
+  Lines 1-2, characters 10-0: syntax error.
+  [3]
+
+
+Mismatch between section-start and section-end:
+
+  $ PROBLEM=foo-bar.mustache
+  $ echo "{{#foo}} {{.}} {{/bar}}" > $PROBLEM
+  $ mustache foo.json $PROBLEM
+  Fatal error: exception Mustache_types.Invalid_template("Mismatched section foo with bar")
+  [2]
+
+  $ PROBLEM=foo-not-closed.mustache
+  $ echo "{{#foo}} {{.}} {{foo}}" > $PROBLEM
+  $ mustache foo.json $PROBLEM
+  Line 2, character 0: syntax error.
+  [3]
+
+  $ PROBLEM=wrong-nesting.mustache
+  $ echo "{{#bar}} {{#foo}} {{.}} {{/bar}} {{/foo}}" > $PROBLEM
+  $ mustache foo.json $PROBLEM
+  Fatal error: exception Mustache_types.Invalid_template("Mismatched section foo with bar")
+  [2]

--- a/bin/test/errors/render-errors.t/invalid-dotted-name-1.json
+++ b/bin/test/errors/render-errors.t/invalid-dotted-name-1.json
@@ -1,0 +1,13 @@
+{
+    "title": "Some Title",
+    "list": [
+        {"data": "foo"},
+        {"data": "bar"},
+        {"data": "baz"}
+    ],
+    "gro": {
+        "first": "First",
+        "second": "Second"
+    },
+    "name": "Some Name"
+}

--- a/bin/test/errors/render-errors.t/invalid-dotted-name-1.mustache
+++ b/bin/test/errors/render-errors.t/invalid-dotted-name-1.mustache
@@ -1,0 +1,17 @@
+Title: {{title}}
+
+List:
+{{#list}}
+  - {{data}}
+{{/list}}
+
+Group:
+{{#group}}
+  {{gro.first}}
+  {{second}}
+{{/group}}
+
+{{#name}}The variable "name" has value "{{name}}".{{/name}}
+{{^name}}The variable "name" is not set. {{/name}}
+
+Last line.

--- a/bin/test/errors/render-errors.t/invalid-dotted-name-2.json
+++ b/bin/test/errors/render-errors.t/invalid-dotted-name-2.json
@@ -1,0 +1,13 @@
+{
+    "title": "Some Title",
+    "list": [
+        {"data": "foo"},
+        {"data": "bar"},
+        {"data": "baz"}
+    ],
+    "group": {
+        "fir": "First",
+        "second": "Second"
+    },
+    "name": "Some Name"
+}

--- a/bin/test/errors/render-errors.t/invalid-dotted-name-2.mustache
+++ b/bin/test/errors/render-errors.t/invalid-dotted-name-2.mustache
@@ -1,0 +1,17 @@
+Title: {{title}}
+
+List:
+{{#list}}
+  - {{data}}
+{{/list}}
+
+Group:
+{{#group}}
+  {{group.fir}}
+  {{second}}
+{{/group}}
+
+{{#name}}The variable "name" has value "{{name}}".{{/name}}
+{{^name}}The variable "name" is not set. {{/name}}
+
+Last line.

--- a/bin/test/errors/render-errors.t/missing-section.json
+++ b/bin/test/errors/render-errors.t/missing-section.json
@@ -1,0 +1,13 @@
+{
+    "title": "Some Title",
+    "list": [
+        {"data": "foo"},
+        {"data": "bar"},
+        {"data": "baz"}
+    ],
+    "grop": {
+        "first": "First",
+        "second": "Second"
+    },
+    "name": "Some Name"
+}

--- a/bin/test/errors/render-errors.t/missing-section.mustache
+++ b/bin/test/errors/render-errors.t/missing-section.mustache
@@ -1,0 +1,17 @@
+Title: {{title}}
+
+List:
+{{#list}}
+  - {{data}}
+{{/list}}
+
+Group:
+{{#group}}
+  {{group.first}}
+  {{second}}
+{{/group}}
+
+{{#na}}The variable "name" has value "{{name}}".{{/na}}
+{{^name}}The variable "name" is not set. {{/name}}
+
+Last line.

--- a/bin/test/errors/render-errors.t/missing-variable.json
+++ b/bin/test/errors/render-errors.t/missing-variable.json
@@ -1,0 +1,13 @@
+{
+    "title": "Some Title",
+    "list": [
+        {"data": "foo"},
+        {"datum": "bar"},
+        {"data": "baz"}
+    ],
+    "group": {
+        "first": "First",
+        "second": "Second"
+    },
+    "name": "Some Name"
+}

--- a/bin/test/errors/render-errors.t/missing-variable.mustache
+++ b/bin/test/errors/render-errors.t/missing-variable.mustache
@@ -1,0 +1,17 @@
+Title: {{title}}
+
+List:
+{{#list}}
+  - {{data}}
+{{/list}}
+
+Group:
+{{#group}}
+  {{group.first}}
+  {{second}}
+{{/group}}
+
+{{#name}}The variable "name" has value "{{na}}".{{/name}}
+{{^name}}The variable "name" is not set. {{/name}}
+
+Last line.

--- a/bin/test/errors/render-errors.t/non-scalar.json
+++ b/bin/test/errors/render-errors.t/non-scalar.json
@@ -1,0 +1,13 @@
+{
+    "title": { "text": "Some Title" },
+    "list": [
+        {"data": "foo"},
+        {"data": "bar"},
+        {"data": "baz"}
+    ],
+    "group": {
+        "first": "First",
+        "second": "Second"
+    },
+    "name": "Some Name"
+}

--- a/bin/test/errors/render-errors.t/non-scalar.mustache
+++ b/bin/test/errors/render-errors.t/non-scalar.mustache
@@ -1,0 +1,16 @@
+Title: {{title}}
+
+List:
+{{list}}
+  - {{data}}
+
+Group:
+{{#group}}
+  {{group.first}}
+  {{second}}
+{{/group}}
+
+{{#name}}The variable "name" has value "{{name}}".{{/name}}
+{{^name}}The variable "name" is not set. {{/name}}
+
+Last line.

--- a/bin/test/errors/render-errors.t/reference.json
+++ b/bin/test/errors/render-errors.t/reference.json
@@ -1,0 +1,13 @@
+{
+    "title": "Some Title",
+    "list": [
+        {"data": "foo"},
+        {"data": "bar"},
+        {"data": "baz"}
+    ],
+    "group": {
+        "first": "First",
+        "second": "Second"
+    },
+    "name": "Some Name"
+}

--- a/bin/test/errors/render-errors.t/reference.mustache
+++ b/bin/test/errors/render-errors.t/reference.mustache
@@ -1,0 +1,17 @@
+Title: {{title}}
+
+List:
+{{#list}}
+  - {{data}}
+{{/list}}
+
+Group:
+{{#group}}
+  {{group.first}}
+  {{second}}
+{{/group}}
+
+{{#name}}The variable "name" has value "{{name}}".{{/name}}
+{{^name}}The variable "name" is not set. {{/name}}
+
+Last line.

--- a/bin/test/errors/render-errors.t/run.t
+++ b/bin/test/errors/render-errors.t/run.t
@@ -1,0 +1,82 @@
+reference.json and reference.mustache work well together, there is no error.
+  $ mustache reference.json reference.mustache
+  Title: Some Title
+  
+  List:
+    - foo
+    - bar
+    - baz
+  
+  Group:
+    First
+    Second
+  
+  The variable "name" has value "Some Name".
+  
+  
+  Last line.
+
+
+Error cases. In many cases, there are two ways to get a given
+rendering error, one is by making a mistake in the template
+(compared to the reference version), the other is to make a mistake in
+the JSON file. We exercise both ways in the tests, to see if the
+context given by error messages makes it easy for users to understand
+one possible source of error, or both, or none.
+
+Invalid variable name:
+
+  $ mustache reference.json missing-variable.mustache
+  Fatal error: exception Mustache_types.Missing_variable("na")
+  [2]
+
+  $ mustache missing-variable.json reference.mustache
+  Fatal error: exception Mustache_types.Missing_variable("data")
+  [2]
+
+Invalid section name:
+
+  $ mustache reference.json missing-section.mustache
+  Fatal error: exception Mustache_types.Missing_section("na")
+  [2]
+
+  $ mustache missing-section.json reference.mustache
+  Fatal error: exception Mustache_types.Missing_section("group")
+  [2]
+
+Error in a dotted path foo.bar (one case for the first component, the other in the second).
+
+  $ mustache reference.json invalid-dotted-name-1.mustache
+  Fatal error: exception Mustache_types.Missing_variable("gro")
+  [2]
+
+  $ mustache invalid-dotted-name-1.json reference.mustache
+  Fatal error: exception Mustache_types.Missing_section("group")
+  [2]
+
+  $ mustache reference.json invalid-dotted-name-2.mustache
+  Fatal error: exception Mustache_types.Missing_variable("fir")
+  [2]
+
+  $ mustache invalid-dotted-name-2.json reference.mustache
+  Fatal error: exception Mustache_types.Missing_variable("first")
+  [2]
+
+Non-scalar used as a scalar:
+
+  $ mustache reference.json non-scalar.mustache
+  Fatal error: exception Mustache_types.Invalid_param("Lookup.scalar: not a scalar")
+  [2]
+
+  $ mustache non-scalar.json reference.mustache
+  Fatal error: exception Mustache_types.Invalid_param("Lookup.scalar: not a scalar")
+  [2]
+
+Missing partial (currently the CLI does not support any partial anyway):
+(this file has a z- prefix so that the files do come in pairs
+(this one does not) are all before in the alphabetic order, resulting
+in better `ls` output).
+
+  $ mustache reference.json z-missing-partial.mustache
+  Fatal error: exception Mustache_types.Missing_partial("second")
+  [2]

--- a/bin/test/errors/render-errors.t/z-missing-partial.mustache
+++ b/bin/test/errors/render-errors.t/z-missing-partial.mustache
@@ -1,0 +1,17 @@
+Title: {{title}}
+
+List:
+{{#list}}
+  - {{data}}
+{{/list}}
+
+Group:
+{{#group}}
+  {{group.first}}
+  {{>second}}
+{{/group}}
+
+{{#name}}The variable "name" has value "{{name}}".{{/name}}
+{{^name}}The variable "name" is not set. {{/name}}
+
+Last line.

--- a/bin/test/errors/sys-errors.t
+++ b/bin/test/errors/sys-errors.t
@@ -1,0 +1,12 @@
+  $ touch foo.json
+  $ touch foo.mustache
+
+Nonexistent json file:
+  $ mustache nonexistent.json foo.mustache
+  Fatal error: exception Sys_error("nonexistent.json: No such file or directory")
+  [2]
+
+Nonexistent template file:
+  $ mustache foo.json nonexistent.mustache
+  Fatal error: exception Sys_error("nonexistent.mustache: No such file or directory")
+  [2]

--- a/dune-project
+++ b/dune-project
@@ -1,6 +1,7 @@
 (lang dune 2.7)
 (name mustache)
 (using menhir 2.0)
+(cram enable)
 
 (license MIT)
 (implicit_transitive_deps false)


### PR DESCRIPTION
This PR (on top of #54, which considerably improves the reference outputs)  contains cram tests for all existing error cases in the Mustache implementation (parse-time and render-time). As is, it is a bit dull; it mostly shows that many errors are not very good. But that is already useful! I intend to rebase #51 on top of it, so that changes in error messages are reflected in the reference outputs, easier to assess for reviewers (and myself). In the future this could also track improvements and regressions in error messages.

(The mere fact of writing those tests made me realize that the error messages in #51 are an improvement, but still vastly insufficient. Basically they work well in the case where there is a mistake (typo, etc.) in the template file, but they do a very poor job if the mistake is in the JSON file.)