### PR TITLE
Partials as includes: support a proper search path

### DIFF
--- a/bin/mustache_cli.ml
+++ b/bin/mustache_cli.ml
@@ -11,10 +11,14 @@ let load_file f =
   close_in ic;
   (Bytes.to_string s)
 
-let locate_template search_path relative_filename =
-  search_path
-  |> List.map (fun path -> Filename.concat path relative_filename)
-  |> List.find_opt Sys.file_exists
+let locate_template search_path filename =
+  if Filename.is_relative filename then
+    search_path
+    |> List.map (fun path -> Filename.concat path filename)
+    |> List.find_opt Sys.file_exists
+  else if Sys.file_exists filename then
+    Some filename
+  else None
 
 let load_template template_filename =
   let template_data = load_file template_filename in

--- a/bin/mustache_cli.ml
+++ b/bin/mustache_cli.ml
@@ -73,6 +73,17 @@ let run_command =
     `P "The $(i,ocaml-mustache) implementation is tested against
         the Mustache specification testsuite.
         All features are supported, except for lambdas and setting delimiter tags.";
+    `S Manpage.s_options;
+    `S "PARTIALS";
+    `P "The $(i,ocaml-mustache) library gives programmatic control over the meaning of partials {{>foo}}.
+        For the $(tname) tool, partials are interpreted as template file inclusion: '{{>foo}}' includes
+        the template file 'foo.mustache'.";
+    `P "Included files are resolved in a search path, which contains the current working directory
+        (unless the $(b,--no-working-dir) option is used)
+        and include directories passed through $(b,-I DIR) options.";
+    `P "If a file exists in several directories of the search path, the directory included first
+        (leftmost $(b,-I) option) has precedence, and the current working directory has precedence
+        over include directories.";
     `S Manpage.s_examples;
     `Pre
       {|
@@ -92,6 +103,25 @@ Hello OCaml!
 Mustache is:
 - simple
 - fun
+
+
+\$ cat page.mustache
+<html>
+  <body>
+    {{>hello}}
+  </body>
+</html>
+
+\$ $(tname) data.json page.mustache
+<html>
+  <body>
+    Hello OCaml!
+    Mustache is:
+    - simple
+    - fun
+  </body>
+</html>
+
 |};
     `S Manpage.s_bugs;
     `P "Report bugs on https://github.com/rgrinberg/ocaml-mustache/issues";

--- a/bin/mustache_cli.ml
+++ b/bin/mustache_cli.ml
@@ -34,7 +34,10 @@ let run json_filename template_filename =
     let path = Printf.sprintf "%s.mustache" name in
     if not (Sys.file_exists path) then None
     else Some (load_template path) in
-  try Mustache.render ~partials tmpl env |> print_endline
+  try
+    let output = Mustache.render ~partials tmpl env in
+    print_string output;
+    flush stdout
   with Mustache.Render_error err ->
     Format.eprintf "Template render error:@\n%a@."
       Mustache.pp_render_error err;

--- a/bin/test/errors/parsing-errors.t
+++ b/bin/test/errors/parsing-errors.t
@@ -62,7 +62,7 @@ Delimiter problems:
   $ echo "{{>" > $PROBLEM
   $ mustache foo.json $PROBLEM
   Template parse error:
-  File "eof-before-partial.mustache", line 2, character 0: ident expected.
+  File "eof-before-partial.mustache", line 2, character 0: '}}' expected.
   [3]
 
   $ PROBLEM=eof-in-comment.mustache

--- a/bin/test/partials.t/run.t
+++ b/bin/test/partials.t/run.t
@@ -3,3 +3,18 @@ Simple test:
   $ mustache data.json foo.mustache
   Inside the include is "Foo Bar !"
   
+Include in child or parent directory:
+  $ mkdir subdir
+  $ echo "Test from {{src}}" > subdir/test.mustache
+  $ echo "{{> subdir/test }}" > from_parent.mustache
+  $ echo '{ "src": "parent" }' > from_parent.json
+  $ mustache from_parent.json from_parent.mustache
+  Test from parent
+  
+
+  $ mkdir subdir/child
+  $ echo "{{> ../test }}" > subdir/child/from_child.mustache
+  $ echo '{ "src": "child" }' > subdir/child/from_child.json
+  $ (cd subdir/child; mustache from_child.json from_child.mustache)
+  Test from child
+  

--- a/bin/test/partials.t/run.t
+++ b/bin/test/partials.t/run.t
@@ -1,8 +1,7 @@
 Simple test:
-
   $ mustache data.json foo.mustache
   Inside the include is "Foo Bar !"
-  
+
 Include in child or parent directory:
   $ mkdir subdir
   $ echo "Test from {{src}}" > subdir/test.mustache
@@ -10,11 +9,9 @@ Include in child or parent directory:
   $ echo '{ "src": "parent" }' > from_parent.json
   $ mustache from_parent.json from_parent.mustache
   Test from parent
-  
 
   $ mkdir subdir/child
   $ echo "{{> ../test }}" > subdir/child/from_child.mustache
   $ echo '{ "src": "child" }' > subdir/child/from_child.json
   $ (cd subdir/child; mustache from_child.json from_child.mustache)
   Test from child
-  

--- a/bin/test/partials.t/run.t
+++ b/bin/test/partials.t/run.t
@@ -15,3 +15,48 @@ Include in child or parent directory:
   $ echo '{ "src": "child" }' > subdir/child/from_child.json
   $ (cd subdir/child; mustache from_child.json from_child.mustache)
   Test from child
+
+When working with templates from outside the current directory,
+we need to set the search path to locate their included partials.
+
+This fails:
+  $ (cd subdir; mustache ../data.json ../foo.mustache)
+  Template render error:
+  File "../foo.mustache", line 2, characters 23-31:
+  the partial 'bar' is missing.
+  [2]
+
+This works with the "-I .." option:
+  $ (cd subdir; mustache -I .. ../data.json ../foo.mustache)
+  Inside the include is "Foo Bar !"
+
+Note that the include directory is *not* used to locate the template
+(or data) argument. This fails:
+  $ (cd subdir; mustache -I .. ../data.json foo.mustache)
+  mustache: TEMPLATE.mustache argument: no `foo.mustache' file or directory
+  Usage: mustache [OPTION]... DATA.json TEMPLATE.mustache
+  Try `mustache --help' for more information.
+  [124]
+
+Search path precedence order.
+  $ mkdir precedence
+  $ mkdir precedence/first
+  $ mkdir precedence/last
+  $ echo "First" > precedence/first/include.mustache
+  $ echo "Last" > precedence/last/include.mustache
+  $ echo "{{>include}}" > precedence/template.mustache
+  $ echo "{}" > precedence/data.json
+
+The include directory added first (left -I option) has precedence
+over the include directories added after:
+  $ (cd precedence; mustache -I first -I last data.json template.mustache)
+  First
+
+The working directory has precedence over the include directories:
+  $ echo "Working" > precedence/include.mustache
+  $ (cd precedence; mustache -I first -I last data.json template.mustache)
+  Working
+
+... unless --no-working-dir is used:
+  $ (cd precedence; mustache --no-working-dir -I first -I last data.json template.mustache)
+  First


### PR DESCRIPTION
This PR, on top of #59, implements a search path for template inclusion. By default the search path contains only the current working directory (the pre-PR behavior), but users can add new include directories with `-I foo/bar`.