### PR TITLE
Minor changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,16 @@ Example usage
 
 ```ocaml
 let tmpl =
-  Mustache.of_string "Hello {{name}}\n\
-                      Mustache is:\n\
-                      {{#qualities}}\
-                      * {{name}}\n\
-                      {{/qualities}}"
+  try
+    Mustache.of_string "Hello {{name}}\n\
+                        Mustache is:\n\
+                        {{#qualities}}\
+                        * {{name}}\n\
+                        {{/qualities}}"
+  with Mustache.Parse_error err ->
+    Format.eprintf "%a@."
+      Mustache.pp_template_parse_error err;
+    exit 3
 
 let json =
   `O [ "name", `String "OCaml"
@@ -24,7 +29,11 @@ let json =
      ]
 
 let rendered =
-  Mustache.render tmpl json
+  try Mustache.render tmpl json
+  with Mustache.Render_error err ->
+    Format.eprintf "%a@."
+      Mustache.pp_render_error err;
+    exit 2
 ```
 
 Spec compliance

--- a/bin/mustache_cli.ml
+++ b/bin/mustache_cli.ml
@@ -53,44 +53,43 @@ let run search_path json_filename template_filename =
       Mustache.pp_render_error err;
     exit 2
 
-let run_command =
-  let open Cmdliner in
-  let doc = "renders Mustache template from JSON data files" in
-  let man = [
-    `S Manpage.s_description;
-    `P "$(tname) is a command-line tool coming with the $(i,ocaml-mustache) library,
-        an OCaml implementation of the Mustache template format.
-        $(tname) takes a data file and a template file as command-line parameters;
-        it renders the populated template on standard output.";
+let manpage = Cmdliner.[
+  `S Manpage.s_description;
+  `P "$(tname) is a command-line tool coming with the $(i,ocaml-mustache) library,
+      an OCaml implementation of the Mustache template format.
+      $(tname) takes a data file and a template file as command-line parameters;
+      it renders the populated template on standard output.";
 
-    `P "Mustache is a simple and popular template format,
-        with library implementations in many programming languages.
-        It is named from its {{..}} delimiters.";
+  `P "Mustache is a simple and popular template format,
+      with library implementations in many programming languages.
+      It is named from its {{..}} delimiters.";
 
-    `I ("Mustache website",
-        "https://mustache.github.io/");
-    `I ("Mustache templates documentation",
-        "https://mustache.github.io/mustache.5.html");
-    `I ("ocaml-mustache website:",
-        "https://github.com/rgrinberg/ocaml-mustache");
+  `I ("Mustache website",
+      "https://mustache.github.io/");
+  `I ("Mustache templates documentation",
+      "https://mustache.github.io/mustache.5.html");
+  `I ("$(i,ocaml-mustache) website:",
+      "https://github.com/rgrinberg/ocaml-mustache");
 
-    `P "The $(i,ocaml-mustache) implementation is tested against
-        the Mustache specification testsuite.
-        All features are supported, except for lambdas and setting delimiter tags.";
-    `S Manpage.s_options;
-    `S "PARTIALS";
-    `P "The $(i,ocaml-mustache) library gives programmatic control over the meaning of partials {{>foo}}.
-        For the $(tname) tool, partials are interpreted as template file inclusion: '{{>foo}}' includes
-        the template file 'foo.mustache'.";
-    `P "Included files are resolved in a search path, which contains the current working directory
-        (unless the $(b,--no-working-dir) option is used)
-        and include directories passed through $(b,-I DIR) options.";
-    `P "If a file exists in several directories of the search path, the directory included first
-        (leftmost $(b,-I) option) has precedence, and the current working directory has precedence
-        over include directories.";
-    `S Manpage.s_examples;
-    `Pre
-      {|
+  `S Manpage.s_options;
+  (* The content of this section is filled by Cmdliner; it is used here
+     to enforce the placement of the non-standard sections below. *)
+
+  `S "PARTIALS";
+  `P "The $(i,ocaml-mustache) library gives programmatic control over the meaning of partials {{>foo}}.
+      For the $(tname) tool, partials are interpreted as template file inclusion: '{{>foo}}' includes
+      the template file 'foo.mustache'.";
+  `P "Included files are resolved in a search path, which contains the current working directory
+      (unless the $(b,--no-working-dir) option is used)
+      and include directories passed through $(b,-I DIR) options.";
+  `P "If a file exists in several directories of the search path, the directory included first
+      (leftmost $(b,-I) option) has precedence, and the current working directory has precedence
+      over include directories.";
+
+  `S Manpage.s_examples;
+  `Pre {|
+## Simple usage.
+
 \$ cat data.json
 { "name": "OCaml",
   "qualities": [{"name": "simple"}, {"name": "fun"}] }
@@ -109,6 +108,8 @@ Mustache is:
 - fun
 
 
+## Using a partial to include a subpage; see $(b,PARTIALS).
+
 \$ cat page.mustache
 <html>
   <body>
@@ -124,13 +125,24 @@ Mustache is:
     - simple
     - fun
   </body>
-</html>
+</html>|};
 
-|};
-    `S Manpage.s_bugs;
-    `P "Report bugs on https://github.com/rgrinberg/ocaml-mustache/issues";
-  ]
-  in
+  `S "CONFORMING TO";
+
+  `P "The $(i,ocaml-mustache) implementation is tested against
+      the Mustache specification testsuite.
+      All features are supported, except for lambdas and setting delimiter tags.";
+
+  `I ("Mustache specification testsuite",
+      "https://github.com/mustache/spec");
+
+  `S "REPORTING BUGS";
+  `P "Report bugs on https://github.com/rgrinberg/ocaml-mustache/issues";
+]
+
+let run_command =
+  let open Cmdliner in
+  let doc = "renders Mustache template from JSON data files" in
   let json_file =
     let doc = "data file in JSON format" in
     Arg.(required & pos 0 (some file) None & info [] ~docv:"DATA.json" ~doc)
@@ -156,7 +168,7 @@ Mustache is:
     Term.(const search_path $ includes $ no_working_dir)
   in
   Term.(const run $ search_path $ json_file $ template_file),
-  Term.info "mustache" ~doc ~man
+  Term.info "mustache" ~doc ~man:manpage
 
 let () =
   let open Cmdliner in

--- a/bin/mustache_cli.ml
+++ b/bin/mustache_cli.ml
@@ -28,8 +28,8 @@ let load_template template_filename =
     lexbuf.lex_curr_p <- { lexbuf.lex_curr_p with pos_fname = template_filename };
   in
   try Mustache.parse_lx lexbuf
-  with Mustache.Template_parse_error err ->
-    Format.eprintf "Template parse error:@\n%a@."
+  with Mustache.Parse_error err ->
+    Format.eprintf "Parse error:@\n%a@."
       Mustache.pp_template_parse_error err;
     exit 3
 

--- a/bin/mustache_cli.ml
+++ b/bin/mustache_cli.ml
@@ -29,7 +29,7 @@ let load_template template_filename =
   in
   try Mustache.parse_lx lexbuf
   with Mustache.Parse_error err ->
-    Format.eprintf "Parse error:@\n%a@."
+    Format.eprintf "%a@."
       Mustache.pp_template_parse_error err;
     exit 3
 
@@ -49,7 +49,7 @@ let run search_path json_filename template_filename =
     print_string output;
     flush stdout
   with Mustache.Render_error err ->
-    Format.eprintf "Template render error:@\n%a@."
+    Format.eprintf "%a@."
       Mustache.pp_render_error err;
     exit 2
 

--- a/bin/test/errors/parsing-errors.t
+++ b/bin/test/errors/parsing-errors.t
@@ -96,7 +96,7 @@ Mismatch between section-start and section-end:
   $ echo "{{#foo}} {{.}} {{/bar}}" > $PROBLEM
   $ mustache foo.json $PROBLEM
   Template parse error:
-  File "foo-bar.mustache", lines 1-2, characters 23-0:
+  File "foo-bar.mustache", line 1, characters 0-23:
   Section mismatch: {{#foo}} is closed by {{/bar}}.
   [3]
 
@@ -111,7 +111,7 @@ Mismatch between section-start and section-end:
   $ echo "{{#bar}} {{#foo}} {{.}} {{/bar}} {{/foo}}" > $PROBLEM
   $ mustache foo.json $PROBLEM
   Template parse error:
-  File "wrong-nesting.mustache", lines 1-2, characters 41-0:
+  File "wrong-nesting.mustache", line 1, characters 9-32:
   Section mismatch: {{#foo}} is closed by {{/bar}}.
   [3]
 

--- a/bin/test/errors/parsing-errors.t
+++ b/bin/test/errors/parsing-errors.t
@@ -4,42 +4,36 @@ Delimiter problems:
   $ PROBLEM=no-closing-mustache.mustache
   $ echo "{{foo" > $PROBLEM
   $ mustache foo.json $PROBLEM
-  Parse error:
   File "no-closing-mustache.mustache", line 2, character 0: '}}' expected.
   [3]
 
   $ PROBLEM=one-closing-mustache.mustache
   $ echo "{{foo}" > $PROBLEM
   $ mustache foo.json $PROBLEM
-  Parse error:
   File "one-closing-mustache.mustache", line 1, character 5: '}}' expected.
   [3]
 
   $ PROBLEM=eof-before-variable.mustache
   $ echo "{{" > $PROBLEM
   $ mustache foo.json $PROBLEM
-  Parse error:
   File "eof-before-variable.mustache", line 2, character 0: ident expected.
   [3]
 
   $ PROBLEM=eof-before-section.mustache
   $ echo "{{#" > $PROBLEM
   $ mustache foo.json $PROBLEM
-  Parse error:
   File "eof-before-section.mustache", line 2, character 0: ident expected.
   [3]
 
   $ PROBLEM=eof-before-section-end.mustache
   $ echo "{{#foo}} {{.}} {{/" > $PROBLEM
   $ mustache foo.json $PROBLEM
-  Parse error:
   File "eof-before-section-end.mustache", line 2, character 0: ident expected.
   [3]
 
   $ PROBLEM=eof-before-inverted-section.mustache
   $ echo "{{^" > $PROBLEM
   $ mustache foo.json $PROBLEM
-  Parse error:
   File "eof-before-inverted-section.mustache", line 2, character 0:
   ident expected.
   [3]
@@ -47,28 +41,24 @@ Delimiter problems:
   $ PROBLEM=eof-before-unescape.mustache
   $ echo "{{{" > $PROBLEM
   $ mustache foo.json $PROBLEM
-  Parse error:
   File "eof-before-unescape.mustache", line 2, character 0: ident expected.
   [3]
 
   $ PROBLEM=eof-before-unescape.mustache
   $ echo "{{&" > $PROBLEM
   $ mustache foo.json $PROBLEM
-  Parse error:
   File "eof-before-unescape.mustache", line 2, character 0: ident expected.
   [3]
 
   $ PROBLEM=eof-before-partial.mustache
   $ echo "{{>" > $PROBLEM
   $ mustache foo.json $PROBLEM
-  Parse error:
   File "eof-before-partial.mustache", line 2, character 0: '}}' expected.
   [3]
 
   $ PROBLEM=eof-in-comment.mustache
   $ echo "{{! non-terminated comment" > $PROBLEM
   $ mustache foo.json $PROBLEM
-  Parse error:
   File "eof-in-comment.mustache", line 2, character 0: non-terminated comment.
   [3]
 
@@ -78,14 +68,12 @@ Mismatches between opening and closing mustaches:
   $ PROBLEM=two-three.mustache
   $ echo "{{ foo }}}" > $PROBLEM
   $ mustache foo.json $PROBLEM
-  Parse error:
   File "two-three.mustache", line 1, characters 7-10: '}}' expected.
   [3]
 
   $ PROBLEM=three-two.mustache
   $ echo "{{{ foo }}" > $PROBLEM
   $ mustache foo.json $PROBLEM
-  Parse error:
   File "three-two.mustache", line 1, characters 8-10: '}}}' expected.
   [3]
 
@@ -95,7 +83,6 @@ Mismatch between section-start and section-end:
   $ PROBLEM=foo-bar.mustache
   $ echo "{{#foo}} {{.}} {{/bar}}" > $PROBLEM
   $ mustache foo.json $PROBLEM
-  Parse error:
   File "foo-bar.mustache", line 1, characters 0-23:
   Section mismatch: {{#foo}} is closed by {{/bar}}.
   [3]
@@ -103,14 +90,12 @@ Mismatch between section-start and section-end:
   $ PROBLEM=foo-not-closed.mustache
   $ echo "{{#foo}} {{.}} {{foo}}" > $PROBLEM
   $ mustache foo.json $PROBLEM
-  Parse error:
   File "foo-not-closed.mustache", line 2, character 0: syntax error.
   [3]
 
   $ PROBLEM=wrong-nesting.mustache
   $ echo "{{#bar}} {{#foo}} {{.}} {{/bar}} {{/foo}}" > $PROBLEM
   $ mustache foo.json $PROBLEM
-  Parse error:
   File "wrong-nesting.mustache", line 1, characters 9-32:
   Section mismatch: {{#foo}} is closed by {{/bar}}.
   [3]
@@ -121,6 +106,5 @@ Weird cases that may confuse our lexer or parser:
   $ PROBLEM=weird-tag-name.mustache
   $ echo "{{.weird}} foo bar" > $PROBLEM
   $ mustache foo.json $PROBLEM
-  Parse error:
   File "weird-tag-name.mustache", line 1, character 3: '}}' expected.
   [3]

--- a/bin/test/errors/parsing-errors.t
+++ b/bin/test/errors/parsing-errors.t
@@ -4,42 +4,42 @@ Delimiter problems:
   $ PROBLEM=no-closing-mustache.mustache
   $ echo "{{foo" > $PROBLEM
   $ mustache foo.json $PROBLEM
-  Template parse error:
+  Parse error:
   File "no-closing-mustache.mustache", line 2, character 0: '}}' expected.
   [3]
 
   $ PROBLEM=one-closing-mustache.mustache
   $ echo "{{foo}" > $PROBLEM
   $ mustache foo.json $PROBLEM
-  Template parse error:
+  Parse error:
   File "one-closing-mustache.mustache", line 1, character 5: '}}' expected.
   [3]
 
   $ PROBLEM=eof-before-variable.mustache
   $ echo "{{" > $PROBLEM
   $ mustache foo.json $PROBLEM
-  Template parse error:
+  Parse error:
   File "eof-before-variable.mustache", line 2, character 0: ident expected.
   [3]
 
   $ PROBLEM=eof-before-section.mustache
   $ echo "{{#" > $PROBLEM
   $ mustache foo.json $PROBLEM
-  Template parse error:
+  Parse error:
   File "eof-before-section.mustache", line 2, character 0: ident expected.
   [3]
 
   $ PROBLEM=eof-before-section-end.mustache
   $ echo "{{#foo}} {{.}} {{/" > $PROBLEM
   $ mustache foo.json $PROBLEM
-  Template parse error:
+  Parse error:
   File "eof-before-section-end.mustache", line 2, character 0: ident expected.
   [3]
 
   $ PROBLEM=eof-before-inverted-section.mustache
   $ echo "{{^" > $PROBLEM
   $ mustache foo.json $PROBLEM
-  Template parse error:
+  Parse error:
   File "eof-before-inverted-section.mustache", line 2, character 0:
   ident expected.
   [3]
@@ -47,28 +47,28 @@ Delimiter problems:
   $ PROBLEM=eof-before-unescape.mustache
   $ echo "{{{" > $PROBLEM
   $ mustache foo.json $PROBLEM
-  Template parse error:
+  Parse error:
   File "eof-before-unescape.mustache", line 2, character 0: ident expected.
   [3]
 
   $ PROBLEM=eof-before-unescape.mustache
   $ echo "{{&" > $PROBLEM
   $ mustache foo.json $PROBLEM
-  Template parse error:
+  Parse error:
   File "eof-before-unescape.mustache", line 2, character 0: ident expected.
   [3]
 
   $ PROBLEM=eof-before-partial.mustache
   $ echo "{{>" > $PROBLEM
   $ mustache foo.json $PROBLEM
-  Template parse error:
+  Parse error:
   File "eof-before-partial.mustache", line 2, character 0: '}}' expected.
   [3]
 
   $ PROBLEM=eof-in-comment.mustache
   $ echo "{{! non-terminated comment" > $PROBLEM
   $ mustache foo.json $PROBLEM
-  Template parse error:
+  Parse error:
   File "eof-in-comment.mustache", line 2, character 0: non-terminated comment.
   [3]
 
@@ -78,14 +78,14 @@ Mismatches between opening and closing mustaches:
   $ PROBLEM=two-three.mustache
   $ echo "{{ foo }}}" > $PROBLEM
   $ mustache foo.json $PROBLEM
-  Template parse error:
+  Parse error:
   File "two-three.mustache", line 1, characters 7-10: '}}' expected.
   [3]
 
   $ PROBLEM=three-two.mustache
   $ echo "{{{ foo }}" > $PROBLEM
   $ mustache foo.json $PROBLEM
-  Template parse error:
+  Parse error:
   File "three-two.mustache", line 1, characters 8-10: '}}}' expected.
   [3]
 
@@ -95,7 +95,7 @@ Mismatch between section-start and section-end:
   $ PROBLEM=foo-bar.mustache
   $ echo "{{#foo}} {{.}} {{/bar}}" > $PROBLEM
   $ mustache foo.json $PROBLEM
-  Template parse error:
+  Parse error:
   File "foo-bar.mustache", line 1, characters 0-23:
   Section mismatch: {{#foo}} is closed by {{/bar}}.
   [3]
@@ -103,14 +103,14 @@ Mismatch between section-start and section-end:
   $ PROBLEM=foo-not-closed.mustache
   $ echo "{{#foo}} {{.}} {{foo}}" > $PROBLEM
   $ mustache foo.json $PROBLEM
-  Template parse error:
+  Parse error:
   File "foo-not-closed.mustache", line 2, character 0: syntax error.
   [3]
 
   $ PROBLEM=wrong-nesting.mustache
   $ echo "{{#bar}} {{#foo}} {{.}} {{/bar}} {{/foo}}" > $PROBLEM
   $ mustache foo.json $PROBLEM
-  Template parse error:
+  Parse error:
   File "wrong-nesting.mustache", line 1, characters 9-32:
   Section mismatch: {{#foo}} is closed by {{/bar}}.
   [3]
@@ -121,6 +121,6 @@ Weird cases that may confuse our lexer or parser:
   $ PROBLEM=weird-tag-name.mustache
   $ echo "{{.weird}} foo bar" > $PROBLEM
   $ mustache foo.json $PROBLEM
-  Template parse error:
+  Parse error:
   File "weird-tag-name.mustache", line 1, character 3: '}}' expected.
   [3]

--- a/bin/test/errors/render-errors.t/run.t
+++ b/bin/test/errors/render-errors.t/run.t
@@ -27,13 +27,11 @@ one possible source of error, or both, or none.
 Invalid variable name:
 
   $ mustache reference.json missing-variable.mustache
-  Template render error:
   File "missing-variable.mustache", line 14, characters 40-46:
   the variable 'na' is missing.
   [2]
 
   $ mustache missing-variable.json reference.mustache
-  Template render error:
   File "reference.mustache", line 5, characters 4-12:
   the variable 'data' is missing.
   [2]
@@ -41,13 +39,11 @@ Invalid variable name:
 Invalid section name:
 
   $ mustache reference.json missing-section.mustache
-  Template render error:
   File "missing-section.mustache", line 14, characters 0-55:
   the section 'na' is missing.
   [2]
 
   $ mustache missing-section.json reference.mustache
-  Template render error:
   File "reference.mustache", lines 9-12, characters 0-10:
   the section 'group' is missing.
   [2]
@@ -55,25 +51,21 @@ Invalid section name:
 Error in a dotted path foo.bar (one case for the first component, the other in the second).
 
   $ mustache reference.json invalid-dotted-name-1.mustache
-  Template render error:
   File "invalid-dotted-name-1.mustache", line 10, characters 2-15:
   the variable 'gro' is missing.
   [2]
 
   $ mustache invalid-dotted-name-1.json reference.mustache
-  Template render error:
   File "reference.mustache", lines 9-12, characters 0-10:
   the section 'group' is missing.
   [2]
 
   $ mustache reference.json invalid-dotted-name-2.mustache
-  Template render error:
   File "invalid-dotted-name-2.mustache", line 10, characters 2-15:
   the variable 'group.fir' is missing.
   [2]
 
   $ mustache invalid-dotted-name-2.json reference.mustache
-  Template render error:
   File "reference.mustache", line 10, characters 2-17:
   the variable 'group.first' is missing.
   [2]
@@ -81,13 +73,11 @@ Error in a dotted path foo.bar (one case for the first component, the other in t
 Non-scalar used as a scalar:
 
   $ mustache reference.json non-scalar.mustache
-  Template render error:
   File "non-scalar.mustache", line 4, characters 0-8:
   the value of 'list' is not a valid scalar.
   [2]
 
   $ mustache non-scalar.json reference.mustache
-  Template render error:
   File "reference.mustache", line 1, characters 7-16:
   the value of 'title' is not a valid scalar.
   [2]
@@ -98,7 +88,6 @@ Missing partial (currently the CLI does not support any partial anyway):
 in better `ls` output).
 
   $ mustache reference.json z-missing-partial.mustache
-  Template render error:
   File "z-missing-partial.mustache", line 11, characters 2-13:
   the partial 'second' is missing.
   [2]

--- a/bin/test/partials.t/run.t
+++ b/bin/test/partials.t/run.t
@@ -21,7 +21,6 @@ we need to set the search path to locate their included partials.
 
 This fails:
   $ (cd subdir; mustache ../data.json ../foo.mustache)
-  Template render error:
   File "../foo.mustache", line 2, characters 23-31:
   the partial 'bar' is missing.
   [2]

--- a/lib/mustache.ml
+++ b/lib/mustache.ml
@@ -157,10 +157,10 @@ and template_parse_error_kind =
 exception Template_parse_error of template_parse_error
 
 let parse_lx (lexbuf: Lexing.lexbuf) : Locs.t =
-  let raise_err lexbuf kind =
-    let loc =
-      let open Lexing in
-      { loc_start = lexbuf.lex_start_p; loc_end = lexbuf.lex_curr_p } in
+  let loc_of lexbuf =
+    let open Lexing in
+    { loc_start = lexbuf.lex_start_p; loc_end = lexbuf.lex_curr_p } in
+  let raise_err loc kind =
     raise (Template_parse_error { loc; kind })
   in
   try
@@ -169,11 +169,11 @@ let parse_lx (lexbuf: Lexing.lexbuf) : Locs.t =
       Mustache_lexer.(handle_standalone mustache lexbuf)
   with
   | Mustache_lexer.Error msg ->
-    raise_err lexbuf (Lexing msg)
+    raise_err (loc_of lexbuf) (Lexing msg)
   | Mustache_parser.Error ->
-    raise_err lexbuf Parsing
-  | Mismatched_section { start_name; end_name } ->
-    raise_err lexbuf (Mismatched_section { start_name; end_name })
+    raise_err (loc_of lexbuf) Parsing
+  | Mismatched_section { loc; start_name; end_name } ->
+    raise_err loc (Mismatched_section { start_name; end_name })
 
 let of_string s = parse_lx (Lexing.from_string s)
 

--- a/lib/mustache.ml
+++ b/lib/mustache.ml
@@ -154,14 +154,14 @@ and template_parse_error_kind =
       end_name: dotted_name;
     }
 
-exception Template_parse_error of template_parse_error
+exception Parse_error of template_parse_error
 
 let parse_lx (lexbuf: Lexing.lexbuf) : Locs.t =
   let loc_of lexbuf =
     let open Lexing in
     { loc_start = lexbuf.lex_start_p; loc_end = lexbuf.lex_curr_p } in
   let raise_err loc kind =
-    raise (Template_parse_error { loc; kind })
+    raise (Parse_error { loc; kind })
   in
   try
     MenhirLib.Convert.Simplified.traditional2revised
@@ -265,8 +265,8 @@ let () =
       pp_error err;
     Buffer.contents buf in
   Printexc.register_printer (function
-    | Template_parse_error err ->
-      Some (pretty_print "Template_parse_error" pp_template_parse_error err)
+    | Parse_error err ->
+      Some (pretty_print "Parse_error" pp_template_parse_error err)
     | Render_error err ->
       Some (pretty_print "Render_error" pp_render_error err)
     | _ -> None

--- a/lib/mustache.mli
+++ b/lib/mustache.mli
@@ -40,9 +40,9 @@ type loc =
     { loc_start: Lexing.position;
       loc_end: Lexing.position }
 
-(** Read template files; those function may raise [Template_parse_error]. *)
+(** Read template files; those function may raise [Parse_error]. *)
 type template_parse_error
-exception Template_parse_error of template_parse_error
+exception Parse_error of template_parse_error
 
 val parse_lx : Lexing.lexbuf -> t
 val of_string : string -> t
@@ -54,7 +54,7 @@ val of_string : string -> t
 
     {|
       try ignore (Mustache.of_string "{{!")
-      with Mustache.Template_parse_error err ->
+      with Mustache.Parse_error err ->
         Format.eprintf "%a@." Mustache.pp_template_parse_error err
     |}
 *)

--- a/lib/mustache_parser.mly
+++ b/lib/mustache_parser.mly
@@ -24,16 +24,17 @@
   open Mustache_types
   open Mustache_types.Locs
 
-  let parse_section start_name end_name contents =
+  let mkloc (start_pos, end_pos) =
+    { loc_start = start_pos;
+      loc_end = end_pos }
+
+  let parse_section loc start_name end_name contents =
     if start_name <> end_name then
-      raise (Mismatched_section { start_name; end_name });
+      raise (Mismatched_section { loc = mkloc loc; start_name; end_name });
     { contents; name = start_name }
 
-  let with_loc (startpos, endpos) desc =
-    let loc =
-      { loc_start = startpos;
-        loc_end = endpos } in
-    { loc; desc }
+  let with_loc loc desc =
+    { loc = mkloc loc; desc }
 %}
 
 %token EOF
@@ -57,13 +58,13 @@ section:
     e = mustache_expr
     se = CLOSE_SECTION {
     with_loc $sloc
-      (Inverted_section (parse_section ss se e))
+      (Inverted_section (parse_section $sloc ss se e))
   }
   | ss = OPEN_SECTION
     e = mustache_expr
     se = CLOSE_SECTION {
     with_loc $sloc
-      (Section (parse_section ss se e))
+      (Section (parse_section $sloc ss se e))
   }
 
 mustache_element:

--- a/lib/mustache_types.ml
+++ b/lib/mustache_types.ml
@@ -85,6 +85,7 @@ end
 (* this exception is used internally in the parser,
    never exposed to users *)
 exception Mismatched_section of {
+  loc: loc;
   start_name: dotted_name;
   end_name: dotted_name;
 }


### PR DESCRIPTION
A bunch of minor changes that I think improve the project. They are mostly unrelated but I didn't want to spam with many unrelated PRs, so I am using a single PR to gather feedback:

- Minor manpage improvements.
- Fix the error location on "tag mismatch" parsing errors.
- Rename `Template_parse_error` into `Parse_error`.
- When pretty-printing errors, stop saying "Template parse error:" or "Template render error:" first.
  This is usually clear from the error message itself, and shorter messages are better.
- Include proper exception-handling in the small code snippet from the README.
  (Hopefully this would encourage users to properly deal with errors in their own code.)