### PR TITLE
proper JSON errors

### DIFF
--- a/bin/dune
+++ b/bin/dune
@@ -2,7 +2,7 @@
  (name mustache_cli)
  (public_name mustache)
  (modules mustache_cli)
- (libraries mustache ezjsonm cmdliner))
+ (libraries mustache jsonm cmdliner))
 
 (rule
  (with-stdout-to mustache.1

--- a/bin/test/errors/json-errors.t
+++ b/bin/test/errors/json-errors.t
@@ -4,14 +4,11 @@
 
 Empty json file:
   $ mustache empty.json foo.mustache
-  mustache: internal error, uncaught exception:
-            Ezjsonm.Parse_error(870828711, "JSON.of_buffer expected JSON text (JSON value)")
-            
-  [125]
+  File "empty.json", line 1, character 0: expected JSON text (JSON value)
+  [4]
 
 Invalid json file:
   $ mustache invalid.json foo.mustache
-  mustache: internal error, uncaught exception:
-            Ezjsonm.Parse_error(870828711, "JSON.of_buffer expected value separator or object end (',' or '}')")
-            
-  [125]
+  File "invalid.json", line 1, characters 15-29:
+  expected value separator or object end (',' or '}')
+  [4]

--- a/dune-project
+++ b/dune-project
@@ -24,8 +24,9 @@ Read and write mustache templates, and render them by providing a json object.
 Contains the `mustache` command line utility for driving logic-less templates.
 ")
  (depends
-  ezjsonm
+  (jsonm (>= 1.0.1))
   (ounit :with-test)
+  (ezjsonm :with-test)
   (menhir (>= 20180703))
   (cmdliner (>= 1.0.4))
   (ocaml (>= 4.06))))

--- a/lib/mustache.mli
+++ b/lib/mustache.mli
@@ -40,6 +40,8 @@ type loc =
     { loc_start: Lexing.position;
       loc_end: Lexing.position }
 
+val pp_loc : Format.formatter -> loc -> unit
+
 (** Read template files; those function may raise [Parse_error]. *)
 type template_parse_error
 exception Parse_error of template_parse_error

--- a/mustache.opam
+++ b/mustache.opam
@@ -17,8 +17,9 @@ homepage: "https://github.com/rgrinberg/ocaml-mustache"
 bug-reports: "https://github.com/rgrinberg/ocaml-mustache/issues"
 depends: [
   "dune" {>= "2.7"}
-  "ezjsonm"
+  "jsonm" {>= "1.0.1"}
   "ounit" {with-test}
+  "ezjsonm" {with-test}
   "menhir" {>= "20180703"}
   "cmdliner" {>= "1.0.4"}
   "ocaml" {>= "4.06"}


### PR DESCRIPTION
Before:

    mustache: internal error, uncaught exception:
              Ezjsonm.Parse_error(870828711, "JSON.of_buffer expected value separator or object end (',' or '}')")

After:

    File "invalid.json", line 1, characters 15-29:
    expected value separator or object end (',' or '}')

Ezjsonm does not provide a way to access error locations. This should
be fixed upstream. Instead we use the underlying library Jsonm
directly, doing the dance of converting its streaming output to
a complete JSON value.