### PR TITLE
A compatibility test against the ocaml-mustache v2.0.0 API

### DIFF
--- a/lib_test/compat/dune
+++ b/lib_test/compat/dune
@@ -1,0 +1,3 @@
+(tests
+ (libraries mustache ezjsonm)
+ (names user_program))

--- a/lib_test/compat/mustache_v200.ml
+++ b/lib_test/compat/mustache_v200.ml
@@ -1,0 +1,41 @@
+(** This test is designed to get a sense of the backward-compatibility
+   impact of changes to the ocaml-mustache library.
+
+   mustache_v200.mli is exactly a copy of the Mustache interface as it
+   existed in the version v2.0.0, and it should not change.
+
+   mustache_v200.ml is a reimplementation of this interface using the
+   current ocaml-mustache library. If the library changes, this
+   reimplementation will have to be fixed as well; the invasiveness of
+   this fix can be used to estimate the invasiveness of the change for
+   end-users.
+
+   v2.0.0 was chosen because it does not contain an explicit AST
+   definition or "fold" function -- whose compatibility breaks for
+   basically any new language feature or representation change
+   (for example when adding locations in the AST).
+*)
+
+include Mustache
+
+(** The exceptions below are not used anymore. *)
+exception Invalid_param of string
+exception Invalid_template of string
+
+let iter_var = Mustache.escaped []
+
+let render_fmt = Mustache.render_fmt ?strict:None ?partials:None
+let render = Mustache.render ?strict:None ?partials:None
+
+open struct
+  let dotted name =
+    String.split_on_char '.' name
+    |> List.filter (fun n -> n <> "")
+end
+
+let escaped name = escaped (dotted name)
+let unescaped name = unescaped (dotted name)
+let inverted_section name = inverted_section (dotted name)
+let section name = section (dotted name)
+
+let partial name = partial ?indent:None ?params:None name (lazy None)

--- a/lib_test/compat/mustache_v200.mli
+++ b/lib_test/compat/mustache_v200.mli
@@ -1,0 +1,61 @@
+(** A module for creating and rendering mustache templates in OCaml. *)
+exception Invalid_param of string
+exception Invalid_template of string
+
+type t
+
+(** Read *)
+val parse_lx : Lexing.lexbuf -> t
+val of_string : string -> t
+
+(** [to_formatter fmt template] print a template as raw mustache to
+    the formatter [fmt].  *)
+val to_formatter : Format.formatter -> t -> unit
+
+(** [to_string template] uses [to_formatter] in order to return
+     a string representing the template as raw mustache.  *)
+val to_string : t -> string
+
+(** [render_fmt fmt template json] render [template], filling it
+    with data from [json], printing it to formatter [fmt]. *)
+val render_fmt : Format.formatter -> t -> Ezjsonm.t -> unit
+
+(** [render template json] use [render_fmt] to render [template]
+    with data from [json] and returns the resulting string. *)
+val render : t -> Ezjsonm.t -> string
+
+(** Shortcut for concatening two templates pieces. *)
+module Infix : sig
+  val (^) : t -> t -> t
+end
+
+(** Escape [&], ["\""], ['], [<] and [>]
+    character for html rendering. *)
+val escape_html : string -> string
+
+(** [{{.}}] *)
+val iter_var : t
+
+(** [<p>This is raw text.</p>] *)
+val raw : string -> t
+
+(** [{{name}}] *)
+val escaped : string -> t
+
+(** [{{{name}}}] *)
+val unescaped : string -> t
+
+(** [{{^person}} {{/person}}] *)
+val inverted_section : string -> t -> t
+
+(** [{{#person}} {{/person}}] *)
+val section : string -> t -> t
+
+(** [{{> box}}] *)
+val partial : string -> t
+
+(** [{{! this is a comment}}] *)
+val comment : string -> t
+
+(** Group a [t list] as a single [t]. *)
+val concat : t list -> t

--- a/lib_test/compat/user_program.expected
+++ b/lib_test/compat/user_program.expected
@@ -1,0 +1,43 @@
+
+# Parsed template
+
+## parsed
+---
+Hello {{ name }}
+Mustache is:
+{{#qualities}}* {{ name }}
+{{/qualities}}
+---
+
+## rendered
+---
+Hello OCaml
+Mustache is:
+* awesome
+* simple
+* fun
+
+---
+
+# Programmed template
+
+## parsed
+---
+Hello {{ name }}
+Mustache is:
+{{#qualities}}* {{ name }}
+{{/qualities}}
+---
+
+## rendered
+---
+Hello OCaml
+Mustache is:
+* awesome
+* simple
+* fun
+
+---
+
+# Output comparison
+Outputs match as expected.

--- a/lib_test/compat/user_program.ml
+++ b/lib_test/compat/user_program.ml
@@ -1,0 +1,66 @@
+module Mustache = Mustache_v200
+(* A simple user program that could have been written against ocaml-mustache 2.0.0;
+   we check that it keeps working as expected. *)
+
+let json =
+  `O [ "name", `String "OCaml"
+     ; "qualities", `A [ `O ["name", `String "awesome"]
+                       ; `O ["name", `String "simple"]
+                       ; `O ["name", `String "fun"]
+                       ]
+     ]
+
+let section heading =
+  print_newline ();
+  print_string "# "; print_endline heading
+let subsection heading =
+  print_newline ();
+  print_string "## "; print_endline heading
+
+let test tmpl =
+  subsection "parsed";
+  print_endline "---";
+  print_endline (Mustache.to_string tmpl);
+  print_endline "---";
+
+  subsection "rendered";
+  print_endline "---";
+  print_endline (Mustache.render tmpl json);
+  print_endline "---";
+  ()
+  
+
+let () = section "Parsed template"
+
+let parsed_template =
+  Mustache.of_string "Hello {{name}}\n\
+                      Mustache is:\n\
+                      {{#qualities}}\n\
+                      * {{name}}\n\
+                      {{/qualities}}\n"
+
+let () = test parsed_template
+
+let () = section "Programmed template"
+
+let programmed_template =
+  let open Mustache in
+  concat [
+    raw "Hello "; escaped "name"; raw "\n";
+    raw "Mustache is:"; raw "\n";
+    section "qualities" @@ concat [
+      raw "* "; escaped "name"; raw "\n";
+    ]
+  ]
+
+let () = test programmed_template
+
+
+let () = section "Output comparison"
+let () =
+  let parsed_output = Mustache.render parsed_template json in
+  let programmed_output = Mustache.render programmed_template json in
+  if String.equal parsed_output programmed_output then
+    print_endline "Outputs match as expected."
+  else 
+    print_endline "Outputs DO NOT match, this is suspcious."


### PR DESCRIPTION
This test is designed to get a sense of the backward-compatibility
impact of changes to the ocaml-mustache library.

mustache_v200.mli is exactly a copy of the Mustache interface as it
existed in the version v2.0.0, and it should not change.

mustache_v200.ml is a reimplementation of this interface using the
current ocaml-mustache library. If the library changes, this
reimplementation will have to be fixed as well; the invasiveness of
this fix can be used to estimate the invasiveness of the change for
end-users.

v2.0.0 was chosen because it does not contain an explicit AST
definition or "fold" function -- whose compatibility breaks for
basically any new language feature or representation
change (for example when adding locations in the AST).