### PR TITLE
Remove the ast without locations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 ### 3.2.0
 
+* Remove the AST without locations: now all functions build an AST with locations;
+  in particular, parsing always provide located error messages.
+  To ease backward-compatibility, the smart constructors still use the
+  same interface, using dummy locations by default, with
+  a With_locations module for users who wish to explicitly provide
+  locations.
+  (@gasche, #65)
 * Support for "template inheritance" (partials with parameters)
   `{{<foo}} {{$param1}}...{{/param1}} {{$param2}}...{{/param2}} {{/foo}`
   following the widely-implemented semi-official specification

--- a/bin/mustache_cli.ml
+++ b/bin/mustache_cli.ml
@@ -1,8 +1,3 @@
-module Mustache = struct
-  include Mustache
-  include With_locations
-end
-
 let load_file f =
   let ic = open_in f in
   let n = in_channel_length ic in

--- a/lib/mustache.mli
+++ b/lib/mustache.mli
@@ -16,10 +16,18 @@ module Json : sig (** Compatible with Ezjsonm *)
     | `O of (string * value) list ]
 end
 
+type loc =
+  { loc_start: Lexing.position;
+    loc_end: Lexing.position }
+
 type name = string
 type dotted_name = string list
 
-type t =
+type t = {
+  loc : loc;
+  desc : desc;
+}
+and desc =
   | String of string
   | Escaped of dotted_name
   | Unescaped of dotted_name
@@ -38,13 +46,9 @@ and partial =
     params: param list option;
     contents: t option Lazy.t }
 and param =
-  { indent: int;
-    name: name;
-    contents: t }
-
-type loc =
-    { loc_start: Lexing.position;
-      loc_end: Lexing.position }
+ { indent: int;
+   name: name;
+   contents: t }
 
 val pp_loc : Format.formatter -> loc -> unit
 

--- a/lib/mustache_parser.mly
+++ b/lib/mustache_parser.mly
@@ -22,7 +22,7 @@
 }}}*/
 %{
   open Mustache_types
-  open Mustache_types.Locs
+  open Mustache_types.Ast
 
   let mkloc (start_pos, end_pos) =
     { loc_start = start_pos;
@@ -53,7 +53,7 @@
 %token <string> RAW
 
 %start mustache
-%type <Mustache_types.Locs.t> mustache
+%type <Mustache_types.Ast.t> mustache
 
 %%
 

--- a/lib/mustache_types.ml
+++ b/lib/mustache_types.ml
@@ -37,40 +37,14 @@ let pp_dotted_name fmt = function
 let string_of_dotted_name n =
   Format.asprintf "%a" pp_dotted_name n
 
-module Locs = struct
+module Ast = struct
   [@@@warning "-30"]
 
-  type desc =
-    | String of string
-    | Escaped of dotted_name
-    | Unescaped of dotted_name
-    | Section of section
-    | Inverted_section of section
-    | Partial of partial
-    | Param of param
-    | Concat of t list
-    | Comment of string
-  and section =
-    { name: dotted_name;
-      contents: t }
-  and partial =
-    { indent: int;
-      name: name;
-      params: param list option;
-      contents: t option Lazy.t }
-  and param =
-   { indent: int;
-     name: name;
-     contents: t }
-  and t =
-    { loc : loc;
-      desc : desc }
-end
-
-module No_locs = struct
-  [@@@warning "-30"]
-
-  type t =
+  type t = {
+    loc : loc;
+    desc : desc;
+  }
+  and desc =
     | String of string
     | Escaped of dotted_name
     | Unescaped of dotted_name

--- a/lib_test/test_mustache.ml
+++ b/lib_test/test_mustache.ml
@@ -165,7 +165,7 @@ let tests_with_locs = With_locations.[
    , [ (`A [], "" )]);
 ]
 
-let roundtrip : t -> t =
+let normalize : t -> t =
   fun t -> erase_locs (add_dummy_locs t)
 
 let () =
@@ -185,10 +185,8 @@ let () =
                 i (Printexc.to_string exn)
             )
         in
-        (Printf.sprintf "%d - erase_locs/add_dummy_locs roundtrip" i
-         >:: assert_equal (roundtrip template) template)
-        :: (Printf.sprintf "%d - parsing" i
-         >:: assert_equal expected_parsing template)
+        (Printf.sprintf "%d - parsing %S" i input
+         >:: assert_equal (normalize expected_parsing) (normalize template))
         :: List.mapi (fun j (data, expected) ->
           let rendered =
             try Mustache.render template data


### PR DESCRIPTION
This change (on top of #64) substantially simplifies the codebase by getting rid of
the duplication of AST definitions. Now there is only one AST, the AST
with locations.

For compatibility reasons we still have With_locations and
Without_locations module, and Without_locations is still the one
exported by default. This means that users that programmatically build
templates through the smart constructors see no change -- they are
just passing dummy-locations everywhere.

(If they were building AST fragments using the variant constructors
directly, they can switch to the smart constructors and have code that
is compatible with both the old and new version of Mustache. If they
were pattern-matching on AST fragments, I would suggest updating the
codebase instead of trying to use 'fold'.)

The new 'compatibility test' still passes, suggesting that this indeed
preserves reasonable (minimal) compatibility.

In the longer term, we could decide to get rid of Without_locations
entirely and expose the With_locations interface by default. However,
it is not so clear that this is really important (if I build an AST
fragment programmatically, I probably don't care about the locations),
and it may require some slight API changes (making the location
argument optional?)

The present change gets most of the practical benefits of switching to
the With_locations world: all users now get proper locations in their
error messages (not just With_locations users). (Notice the related
simplification in mustache_cli.ml.)

(cc @Armael, the initial architect of the With_locations transition)