### PR TITLE
Partial blocks: reject non-parameter tags

### DIFF
--- a/bin/test/inheritance.t/invalid-partial-usage.mustache
+++ b/bin/test/inheritance.t/invalid-partial-usage.mustache
@@ -1,0 +1,10 @@
+{{<base}}
+  This text is ignored.
+  {{$header}}
+    This is a parameter as expected.
+  {{/header}}
+  {{! commments are also fine }}
+  {{#content}}
+    This is a typo, it should be $content.
+  {{/content}}
+{{/base}}

--- a/bin/test/inheritance.t/run.t
+++ b/bin/test/inheritance.t/run.t
@@ -1,7 +1,9 @@
   $ echo "{}" > data.json
 
-This test is the reference example from the template-inheritance specification:
-https://github.com/mustache/spec/pull/75
+# Reference example
+
+This test is the reference example from the template-inheritance
+specification: https://github.com/mustache/spec/pull/75
 
   $ cat data.json         # the json data
   {}
@@ -42,7 +44,7 @@ https://github.com/mustache/spec/pull/75
   </html>
 
 
-We also test the indentation of parameter blocks.
+# Indentation of parameter blocks
 
   $ cat test-indentation.mustache
   <p>
@@ -79,3 +81,27 @@ We also test the indentation of parameter blocks.
     This text is very indented in the source,
     it should be indented naturally in the output.
   </p>
+
+
+# Errors on invalid partial block content
+
+Inside a partial block, we expect parameter blocks. The specification
+mandates that text be accepted and ignored, but we error on other tags.
+
+  $ cat invalid-partial-usage.mustache
+  {{<base}}
+    This text is ignored.
+    {{$header}}
+      This is a parameter as expected.
+    {{/header}}
+    {{! commments are also fine }}
+    {{#content}}
+      This is a typo, it should be $content.
+    {{/content}}
+  {{/base}}
+
+  $ mustache data.json invalid-partial-usage.mustache
+  File "invalid-partial-usage.mustache", lines 7-9, characters 2-14:
+  Inside the partial block {{< base }}...{{/ base }},
+  we expect parameter blocks {{$foo}...{{/foo}} but no other sorts of tags.
+  [3]

--- a/bin/test/inheritance.t/run.t
+++ b/bin/test/inheritance.t/run.t
@@ -3,6 +3,34 @@
 This test is the reference example from the template-inheritance specification:
 https://github.com/mustache/spec/pull/75
 
+  $ cat data.json         # the json data
+  {}
+
+  $ cat mypage.mustache   # the page the user would write
+  {{<base}}
+    {{$header}}
+      {{<header}}
+        {{$title}}My page title{{/title}}
+      {{/header}}
+    {{/header}}
+    {{$content}}
+      <h1>Hello world</h1>
+    {{/content}}
+  {{/base}}
+
+  $ cat base.mustache     # the base layout
+  <html>
+    {{$header}}{{/header}}
+    <body>
+      {{$content}}{{/content}}
+    </body>
+  </html>
+
+  $ cat header.mustache   # this is slightly overkill...
+  <head>
+    <title>{{$title}}Default title{{/title}}</title>
+  </head>
+
   $ mustache data.json mypage.mustache
   <html>
     <head>
@@ -16,12 +44,34 @@ https://github.com/mustache/spec/pull/75
 
 We also test the indentation of parameter blocks.
 
+  $ cat test-indentation.mustache
+  <p>
+    The test below should be indented in the same way as this line.
+    {{$indented-block}}{{/indented-block}}
+  </p>
+
+  $ cat test-indent-more.mustache
+  {{<test-indentation}}
+  {{$indented-block}}
+  This text is not indented in the source,
+  it should be indented naturally in the output.
+  {{/indented-block}}
+  {{/test-indentation}}
+
   $ mustache data.json test-indent-more.mustache
   <p>
     The test below should be indented in the same way as this line.
     This text is not indented in the source,
     it should be indented naturally in the output.
   </p>
+
+  $ cat test-indent-less.mustache
+  {{<test-indentation}}
+      {{$indented-block}}
+      This text is very indented in the source,
+      it should be indented naturally in the output.
+      {{/indented-block}}
+  {{/test-indentation}}
 
   $ mustache data.json test-indent-less.mustache
   <p>

--- a/lib/mustache_types.ml
+++ b/lib/mustache_types.ml
@@ -87,5 +87,6 @@ type name_mismatch_error =
   ; end_name : name
   }
 
-(* this exception is used internally in the parser, never exposed to users *)
+(* these exceptions are used internally in the parser, never exposed to users *)
 exception Mismatched_names of loc * name_mismatch_error
+exception Invalid_as_partial_parameter of name * Ast.t


### PR DESCRIPTION
This is a minor addition to the implementation of partial blocks: inside a `{{<foo}}...{{/foo}}`, we are looking for parameter blocks `{{$bar}}....{{/bar}}`, raw text is ignored (and comments), but other tags were previously silently ignored, and now they result in an error.