### PR TITLE
tests: define package for all test stanzas

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,4 @@
-(lang dune 2.7)
+(lang dune 2.8)
 (name mustache)
 (using menhir 2.0)
 (cram enable)

--- a/mustache-cli.opam
+++ b/mustache-cli.opam
@@ -16,7 +16,7 @@ license: "MIT"
 homepage: "https://github.com/rgrinberg/ocaml-mustache"
 bug-reports: "https://github.com/rgrinberg/ocaml-mustache/issues"
 depends: [
-  "dune" {>= "2.7"}
+  "dune" {>= "2.8"}
   "jsonm" {>= "1.0.1"}
   "mustache" {= version}
   "cmdliner" {>= "1.1.0"}

--- a/mustache-cli/dune
+++ b/mustache-cli/dune
@@ -5,9 +5,11 @@
  (libraries mustache jsonm cmdliner))
 
 (rule
- (deps (:bin mustache_cli.exe))
+ (deps
+  (:bin mustache_cli.exe))
  (action
-  (with-stdout-to mustache.1
+  (with-stdout-to
+   mustache.1
    (run %{bin} --help=groff))))
 
 (install

--- a/mustache-cli/test/dune
+++ b/mustache-cli/test/dune
@@ -1,2 +1,3 @@
 (cram
+ (package mustache-cli)
  (deps %{bin:mustache-ocaml}))

--- a/mustache-cli/test/errors/dune
+++ b/mustache-cli/test/errors/dune
@@ -1,2 +1,3 @@
 (cram
+ (package mustache-cli)
  (deps %{bin:mustache-ocaml}))

--- a/mustache.opam
+++ b/mustache.opam
@@ -15,7 +15,7 @@ license: "MIT"
 homepage: "https://github.com/rgrinberg/ocaml-mustache"
 bug-reports: "https://github.com/rgrinberg/ocaml-mustache/issues"
 depends: [
-  "dune" {>= "2.7"}
+  "dune" {>= "2.8"}
   "ounit2" {with-test}
   "ezjsonm" {with-test}
   "menhir" {>= "20180703"}

--- a/mustache/lib_test/compat/dune
+++ b/mustache/lib_test/compat/dune
@@ -1,3 +1,4 @@
 (tests
  (libraries mustache ezjsonm)
+ (package mustache)
  (names user_program))

--- a/mustache/lib_test/dune
+++ b/mustache/lib_test/dune
@@ -1,6 +1,7 @@
 (tests
  (libraries mustache ounit2 ezjsonm)
  (names test_mustache spec_mustache)
+ (package mustache)
  (deps
   test_mustache.exe
   (glob_files ../specs/*.json)))


### PR DESCRIPTION
This avoids running all tests as part of both packages, which is not possible
    
Language version for dune was updated to be able to define a package for cram stanzas